### PR TITLE
Add install aptitude at start

### DIFF
--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -1,9 +1,8 @@
 ---
-- name: "Install Aptitude required by Ansible"
-  raw: apt-get install aptitude -y
-  become: true
-  become_user: root
-  become_method: sudo
+- name: "Install Aptitude"
+  apt:
+    name: aptitude
+    state: present
 
 - name: Update apt-cache
   apt:

--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -1,4 +1,10 @@
 ---
+- name: "Install Aptitude required by Ansible"
+  raw: apt-get install aptitude -y
+  become: true
+  become_user: root
+  become_method: sudo
+
 - name: Update apt-cache
   apt:
     update_cache: yes


### PR DESCRIPTION
Added install step for Aptitude right at the start of the general tasks. Aptitude is required for the "Upgrade all packages" step to succeed.