### PR TITLE
Add support for emby

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ just a stock Ubuntu install, some clever Ansible config and a bunch of docker co
 * Any number of Samba shares for you to store your stuff
 * A BitTorrent client
 * Various media management tools - Sonarr, Sickrage, CouchPotato, Radarr
-* Media streaming via Plex
+* Media streaming via Plex or Emby
 * A Docker host with Portainer for image and container management
 * Various ways to see stats about your NAS - Glances, dashboards in Grafana
 * A backup tool - allows scheduled backups to Amazon S3, OneDrive, Dropbox etc
@@ -20,6 +20,7 @@ just a stock Ubuntu install, some clever Ansible config and a bunch of docker co
 
   - [CouchPotato](https://couchpota.to/) for downloading and managing movies
   - [Duplicati](https://www.duplicati.com/) for backing up your stuff
+  - [Emby](https://emby.media/) - Media streaming and management
   - [Glances](https://nicolargo.github.io/glances/) for seeing the state of your system via a web browser
   - [Grafana](https://github.com/grafana/grafana) - Dashboarding tool
   - [InfluxDB](https://github.com/influxdata/influxdb) - Time series database used for stats collection

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -13,6 +13,8 @@ transmission_enabled: false
 plex_enabled: false
 tautulli_enabled: false
 
+# Emby
+emby_enabled: false
 
 # Media Sourcing
 sonarr_enabled: false
@@ -159,6 +161,14 @@ plex_tv_directory: "{{ tv_root }}"
 plex_user_id: 0
 plex_group_id: 0
 
+###
+### Emby
+###
+emby_config_directory: "{{ docker_home }}/emby/config"
+emby_movies_directory: "{{ movies_root }}"
+emby_tv_directory: "{{ tv_root }}"
+emby_user_id: 0
+emby_group_id: 0
 
 ###
 ### Tautulli

--- a/nas.yml
+++ b/nas.yml
@@ -13,6 +13,10 @@
     when: plex_enabled == true
     tags: plex
 
+  - import_tasks: tasks/emby.yml
+    when: emby_enabled == true
+    tags: emby
+
   - import_tasks: tasks/tautulli.yml
     when: tautulli_enabled == true
     tags: tautulli

--- a/tasks/emby.yml
+++ b/tasks/emby.yml
@@ -1,0 +1,27 @@
+- name: Create Emby Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    # mode: 0755
+  with_items:
+    - "{{ emby_config_directory }}"
+
+- name: emby Docker Container
+  docker_container:
+    name: emby
+    image: emby/embyserver
+    pull: true
+    volumes:
+      - "{{ emby_config_directory }}:/config:rw"
+      - "{{ emby_movies_directory }}:/movies:rw"
+      - "{{ emby_tv_directory }}:/tv:rw"
+      - "/etc/timezone:/etc/timezone:ro"
+    network_mode: "host"
+    ports:
+      - "8096:8096" # HTTP port
+      - "8920:8920" # HTTP port
+    env:
+      PUID: "{{ emby_user_id }}"
+      PGID: "{{ emby_group_id }}"
+    restart_policy: unless-stopped
+    memory: 1g

--- a/tasks/emby.yml
+++ b/tasks/emby.yml
@@ -19,7 +19,7 @@
     network_mode: "host"
     ports:
       - "8096:8096" # HTTP port
-      - "8920:8920" # HTTP port
+      - "8920:8920" # HTTPS port
     env:
       PUID: "{{ emby_user_id }}"
       PGID: "{{ emby_group_id }}"

--- a/tasks/emby.yml
+++ b/tasks/emby.yml
@@ -2,7 +2,6 @@
   file:
     path: "{{ item }}"
     state: directory
-    # mode: 0755
   with_items:
     - "{{ emby_config_directory }}"
 
@@ -16,7 +15,6 @@
       - "{{ emby_movies_directory }}:/movies:rw"
       - "{{ emby_tv_directory }}:/tv:rw"
       - "/etc/timezone:/etc/timezone:ro"
-    network_mode: "host"
     ports:
       - "8096:8096" # HTTP port
       - "8920:8920" # HTTPS port


### PR DESCRIPTION
Including support for running the Emby container

https://emby.media/

Official container is at:
https://hub.docker.com/r/emby/embyserver/

In a future PR, I'll add support for SSL connections using Let's Encrypt.