### PR TITLE
Fix issue #13. Allows upgrade to work without aptitude installed

### DIFF
--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -6,7 +6,7 @@
 
 - name: Upgrade all packages
   apt:
-    name: "*"
+    upgrade: true
     state: latest
   when: keep_packages_updated == true
 


### PR DESCRIPTION
Based on info from https://github.com/ansible/ansible/issues/32022, I made this small change and saw:

```
TASK [Upgrade all packages] ******************************
 [WARNING]: Could not find aptitude. Using apt-get instead.
```

in the playbook output instead of the failure we've been seeing. Also, packages were updated correctly.