### PR TITLE
Add basic timezone support

### DIFF
--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -43,6 +43,11 @@ znc_enabled: false
 # Sets the hostname of your Ansible NAS
 ansible_nas_hostname: bender
 
+# Sets the timezone for your Ansible NAS
+# You can find a list here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# Don't use the ones marked as Deprecated
+ansible_nas_timezone: Etc/UTC
+
 # Update all apt packages when playbook is run
 keep_packages_updated: false
 

--- a/tasks/couchpotato.yml
+++ b/tasks/couchpotato.yml
@@ -17,10 +17,10 @@
       - "{{ couchpotato_downloads_directory }}/completed:/downloads:rw"
       - "{{ couchpotato_movies_directory }}:/movies:rw"
       - "{{ couchpotato_torrents_directory }}:/torrents:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     ports:
       - "5050:5050"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ couchpotato_user_id }}"
       PGID: "{{ couchpotato_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/emby.yml
+++ b/tasks/emby.yml
@@ -14,11 +14,11 @@
       - "{{ emby_config_directory }}:/config:rw"
       - "{{ emby_movies_directory }}:/movies:rw"
       - "{{ emby_tv_directory }}:/tv:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     ports:
       - "8096:8096" # HTTP port
       - "8920:8920" # HTTPS port
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ emby_user_id }}"
       PGID: "{{ emby_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -27,3 +27,7 @@
 - name: "Set hostname to {{ ansible_nas_hostname }}"
   hostname:
     name: "{{ ansible_nas_hostname }}"
+
+- name: "Set timezone to {{ ansible_nas_timezone }}"
+  timezone:
+    name: "{{ ansible_nas_timezone }}"

--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -15,9 +15,9 @@
       - "{{ plex_config_directory }}:/config:rw"
       - "{{ plex_movies_directory }}:/movies:rw"
       - "{{ plex_tv_directory }}:/tv:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     network_mode: "host"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ plex_user_id }}"
       PGID: "{{ plex_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/radarr.yml
+++ b/tasks/radarr.yml
@@ -12,7 +12,6 @@
     image: linuxserver/radarr
     pull: true
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "{{ radarr_movies_directory }}:/movies:rw"
       - "{{ radarr_download_directory }}/downloads:/downloads:rw"
       - "{{ radarr_data_directory }}:/config:rw"

--- a/tasks/radarr.yml
+++ b/tasks/radarr.yml
@@ -16,10 +16,10 @@
       - "{{ radarr_movies_directory }}:/movies:rw"
       - "{{ radarr_download_directory }}/downloads:/downloads:rw"
       - "{{ radarr_data_directory }}:/config:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     ports:
       - "7878:7878"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ radarr_user_id }}"
       PGID: "{{ radarr_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/sickrage.yml
+++ b/tasks/sickrage.yml
@@ -16,10 +16,10 @@
       - "{{ sickrage_config_directory }}:/config:rw"
       - "{{ sickrage_downloads_directory }}/completed:/downloads:rw"
       - "{{ sickrage_tv_directory }}:/tv:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     ports:
       - "8081:8081"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ sickrage_user_id }}"
       PGID: "{{ sickrage_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/sonarr.yml
+++ b/tasks/sonarr.yml
@@ -12,7 +12,6 @@
     image: linuxserver/sonarr
     pull: true
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
       - "{{ sonarr_tv_directory }}:/tv:rw"
       - "{{ sonarr_download_directory }}/complete:/downloads:rw"
       - "{{ sonarr_data_directory }}:/config:rw"

--- a/tasks/sonarr.yml
+++ b/tasks/sonarr.yml
@@ -16,10 +16,10 @@
       - "{{ sonarr_tv_directory }}:/tv:rw"
       - "{{ sonarr_download_directory }}/complete:/downloads:rw"
       - "{{ sonarr_data_directory }}:/config:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     ports:
       - "8989:8989"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ sonarr_user_id }}"
       PGID: "{{ sonarr_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/tautulli.yml
+++ b/tasks/tautulli.yml
@@ -13,9 +13,9 @@
     pull: true
     volumes:
       - "{{ tautulli_config_directory }}:/config:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     network_mode: "host"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ tautulli_user_id }}"
       PGID: "{{ tautulli_group_id }}"
     restart_policy: unless-stopped

--- a/tasks/transmission.yml
+++ b/tasks/transmission.yml
@@ -18,11 +18,11 @@
       - "{{ transmission_config_directory }}:/config:rw"
       - "{{ transmission_download_directory }}:/downloads:rw"
       - "{{ transmission_watch_directory }}:/watch:rw"
-      - "/etc/timezone:/etc/timezone:ro"
     ports:
       - "9092:9091"
       - "51414:51413"
     env:
+      TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ transmission_user_id }}"
       PGID: "{{ transmission_group_id }}"
     restart_policy: unless-stopped


### PR DESCRIPTION
Added in the basic code for setting the timezone, and also updated all the containers that I could see that would use it directly. A couple still mount /etc/timezone, and I can't find any info on their pages that they support the TZ environment variable.

I ran the playbook with all of the relevant containers enabled, and they all appear to set the timezone correcctly. (Some you can see in the GUI, others I connected to the console and ran the 'date' command).

I have a follow up to this PR that includes support for setting up NTP. I'll raise that one also.