### PR TITLE
Python 3, Ansible Roles, revise package install step

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,3 +1,3 @@
 [all]
-192.168.1.30
+192.168.1.30 ansible_python_interpreter=/usr/bin/python3
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,6 +1,6 @@
 ---
 - name: geerlingguy.docker
-  version: 2.1.0
+  version: 2.5.2
 
 - name: bertvv.samba
-  version: v2.5.0
+  version: v2.7.0

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -1,7 +1,7 @@
 ---
-- name: install pip
+- name: install python3-pip
   apt:
-    name: python-pip
+    name: python3-pip
     state: present
 
 - name: 'Install docker-py'

--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -1,4 +1,7 @@
 ---
+- name: Enable Universe repository
+  raw: apt-add-repository universe
+
 - name: Update apt-cache
   apt:
     update_cache: yes
@@ -12,15 +15,15 @@
 
 - name: Install some packages
   apt:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - smartmontools
-    - htop
-    - zfsutils-linux
-    - bonnie++
-    - unzip
-    - lm-sensors
+    name: "{{ packages }}"
+  vars:
+    packages:
+      - smartmontools
+      - htop
+      - zfsutils-linux
+      - bonnie++
+      - unzip
+      - lm-sensors
 
 #  - name: Configure smartmontools
 


### PR DESCRIPTION
By default, Ubuntu 18.04 LTS comes with python 3 only. Running this playbook from a remote system caused errors if not setting things to Python 3 (or installing python 2 ahead of time). Ironically, samba still needs python 2, so it gets installed there.

Updated the ansible roles in requirements.yml to the latest

The {{item}} method for the apt module is going to be deprecated (or so the warning screen told me). This is the now the approved away of installing multiple packages