### PR TITLE
Update syntax to remove deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ inventory
 roles
 *.retry
 *.log
+
+# Vim
+[._]sw[a-p]
+
+# Session
+Session.vim

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -66,6 +66,9 @@ ansible_nas_email: me@example.com
 # Applications will have subdomain SSL certificates created, eg ansible-nas.<your-domain>, nextcloud.<your-domain>
 ansible_nas_domain: example.com
 
+# Install extra packages
+ansible_nas_extra_packages: ['smartmontools', 'htop', 'zfsutils-linux', 'bonnie++', 'unzip', 'lm-sensors']
+
 ###
 ### Docker
 ###

--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -21,7 +21,7 @@
 
 - name: Install some packages
   apt:
-    name: ['smartmontools', 'htop', 'zfsutils-linux', 'bonnie++', 'unzip', 'lm-sensors']
+    name: "{{ ansible_nas_extra_packages }}"
     state: present
   register: result
   until: result is succeeded

--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -21,15 +21,8 @@
 
 - name: Install some packages
   apt:
-    name: "{{ item }}"
+    name: ['smartmontools', 'htop', 'zfsutils-linux', 'bonnie++', 'unzip', 'lm-sensors']
     state: present
-  with_items:
-    - smartmontools
-    - htop
-    - zfsutils-linux
-    - bonnie++
-    - unzip
-    - lm-sensors
   register: result
   until: result is succeeded
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -66,6 +66,9 @@ ansible_nas_email: me@example.com
 # Applications will have subdomain SSL certificates created, eg ansible-nas.<your-domain>, nextcloud.<your-domain>
 ansible_nas_domain: example.com
 
+# Install extra packages
+ansible_nas_extra_packages: ['smartmontools', 'htop', 'zfsutils-linux', 'bonnie++', 'unzip', 'lm-sensors']
+
 ###
 ### Docker
 ###


### PR DESCRIPTION
- Warning:
TASK [Install some packages] ***************************************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via          
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: ['smartmontools',        
'htop', 'zfsutils-linux', 'bonnie++', 'unzip', 'lm-sensors']` and remove the 
loop. This feature will be removed in version 2.11. Deprecation warnings can be 
 disabled by setting deprecation_warnings=False in ansible.cfg.   