### PR TITLE
Some basic defaults changes

### DIFF
--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -7,7 +7,7 @@
 # Traefik will allow access to certain applications externally. To enable this you'll need a domain name that points to your 
 # home static IP address, or use a dynamic DNS provider like no-ip. You'll also need to map ports 80 and 443 from your router
 # to your ansible-nas server.
-traefik_enabled: true
+traefik_enabled: false
 
 # BitTorrent
 # If you plan to use Transmission with OpenVPN, you'll need to copy group_vars/vpn_credentials.yml.dist
@@ -29,7 +29,7 @@ couchpotato_enabled: false
 radarr_enabled: false
 
 # Music
-airsonic_enabled: true
+airsonic_enabled: false
 
 # News
 miniflux_enabled: false
@@ -43,7 +43,7 @@ netdata_enabled: false
 watchtower_enabled: false
 
 # Backup & Restore
-duplicati_enabled: true
+duplicati_enabled: false
 nextcloud_enabled: false
 gitea_enabled: false
 
@@ -62,7 +62,7 @@ ansible_nas_hostname: ansible-nas
 ansible_nas_timezone: Etc/UTC
 
 # Update all apt packages when playbook is run
-keep_packages_updated: false
+keep_packages_updated: true
 
 # Will be added to the docker group to give user command line access to docker
 ansible_nas_user: david

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -35,6 +35,7 @@ airsonic_enabled: false
 miniflux_enabled: false
 
 # System Management
+heimdall_enabled: true
 portainer_enabled: true
 glances_enabled: true
 stats_enabled: false

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -62,7 +62,7 @@ ansible_nas_hostname: ansible-nas
 ansible_nas_timezone: Etc/UTC
 
 # Update all apt packages when playbook is run
-keep_packages_updated: true
+keep_packages_updated: false
 
 # Will be added to the docker group to give user command line access to docker
 ansible_nas_user: david

--- a/nas.yml
+++ b/nas.yml
@@ -32,6 +32,7 @@
     tags: traefik
 
   - import_tasks: tasks/heimdall.yml
+    when: heimdall_enabled
     tags: heimdall
 
   - import_tasks: tasks/watchtower.yml

--- a/nas.yml
+++ b/nas.yml
@@ -23,16 +23,16 @@
   - import_tasks: tasks/docker.yml
     tags: docker
 
+  - import_tasks: tasks/portainer.yml
+    when: portainer_enabled
+    tags: portainer
+
   - import_tasks: tasks/traefik.yml
     when: traefik_enabled
     tags: traefik
 
   - import_tasks: tasks/heimdall.yml
     tags: heimdall
-
-  - import_tasks: tasks/portainer.yml
-    when: portainer_enabled
-    tags: portainer
 
   - import_tasks: tasks/watchtower.yml
     when: watchtower_enabled
@@ -113,5 +113,3 @@
   - import_tasks: tasks/airsonic.yml
     when: airsonic_enabled
     tags: airsonic
-
-

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -63,7 +63,7 @@ ansible_nas_hostname: ansible-nas-test
 ansible_nas_timezone: Etc/UTC
 
 # Update all apt packages when playbook is run
-keep_packages_updated: true
+keep_packages_updated: false
 
 # Will be added to the docker group to give user command line access to docker
 ansible_nas_user: david

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,7 +7,7 @@
 # Traefik will allow access to certain applications externally. To enable this you'll need a domain name that points to your 
 # home static IP address, or use a dynamic DNS provider like no-ip. You'll also need to map ports 80 and 443 from your router
 # to your ansible-nas server.
-traefik_enabled: true
+traefik_enabled: false
 
 # BitTorrent
 # If you plan to use Transmission with OpenVPN, you'll need to copy group_vars/vpn_credentials.yml.dist
@@ -62,7 +62,7 @@ ansible_nas_hostname: ansible-nas-test
 ansible_nas_timezone: Etc/UTC
 
 # Update all apt packages when playbook is run
-keep_packages_updated: false
+keep_packages_updated: true
 
 # Will be added to the docker group to give user command line access to docker
 ansible_nas_user: david

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -35,6 +35,7 @@ airsonic_enabled: false
 miniflux_enabled: false
 
 # System Management
+heimdall_enabled: false
 portainer_enabled: false
 glances_enabled: false
 stats_enabled: false


### PR DESCRIPTION
A suggestion for some basic defaults changes. Reasoning inline

* Traefik - disabled by default
  * Not everyone is going to need or want external access to their containers.
* airsonic - disabled by default
  * I'm guessing this was a mistake when airsonic was added
* duplicati - disabled by default
  * Not everyone will want / be able to use the backup service. It almost certainly warrants some investigation before enabling and using it
* keep packages updated - enabled by default
  * Good practice to keep your system updated
* Moved portainer to first installed container
  * I encountered a situation where traefik container broke (whilst I was working on another PR), and I wanted to delete it. I used the docker CLI, but it did occur to me that it would be great if container management was there from there start.