### PR TITLE
Add missing variable for test.yml

### DIFF
--- a/tests/test.yml
+++ b/tests/test.yml
@@ -198,6 +198,8 @@ ansible_nas_extra_packages:
   - unzip
   - lm-sensors
 
+ansible_python_interpreter: /usr/bin/python3
+
 ###
 ### Samba
 ###


### PR DESCRIPTION
Fix error when running tests/test-vagrant.sh:
Unable to find any of pip2, pip to use.  pip needs to be installed.