### PR TITLE
Issue 37 restructure downloads directory

### DIFF
--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -277,7 +277,6 @@ heimdall_data_directory: "{{ docker_home }}/heimdall"
 transmission_available_externally: "false"
 transmission_with_openvpn_available_externally: "false"
 transmission_config_directory: "{{ docker_home }}/transmission/config"
-transmission_download_directory: "{{ downloads_root }}"
 transmission_watch_directory: "{{ torrents_root }}"
 transmission_user_id: 0
 transmission_group_id: 0

--- a/tasks/transmission.yml
+++ b/tasks/transmission.yml
@@ -6,18 +6,46 @@
     # mode: 0755
   with_items:
     - "{{ transmission_config_directory }}"
-    - "{{ transmission_download_directory }}"
-    - "{{ transmission_watch_directory }}"
+    - "{{ downloads_root }}/transmission"
+    - "{{ torrents_root }}"
+
+# Check for folders in the old location
+- name: Check for old transmission complete folder
+  stat:
+    path: "{{ downloads_root }}/complete"
+  register: tcf
+
+- name: Check for old transmission incomplete folder
+  stat:
+    path: "{{ downloads_root }}/incomplete"
+  register: tif
+
+# - name: Delete current transmission container
+#   docker_container:
+#     name: transmission
+#     state: absent
+#   when: tcf.stat.isdir is defined and tcf.stat.isdir
+
+- name: Move transmission complete folder to new location
+  command: mv "{{ downloads_root }}/complete" "{{ downloads_root }}/transmission"
+  when: tcf.stat.isdir is defined and tcf.stat.isdir
+  register: tcf_move
+
+- name: Move transmission incomplete folder to new location
+  command: mv "{{ downloads_root }}/incomplete" "{{ downloads_root }}/transmission"
+  when: tif.stat.isdir is defined and tif.stat.isdir
+  register: tif_move
 
 - name: Transmission Docker Container
   docker_container:
     name: transmission
     image: linuxserver/transmission
     pull: true
+    state: started
     volumes:
-      - "{{ transmission_config_directory }}:/config:rw"
-      - "{{ transmission_download_directory }}:/downloads:rw"
-      - "{{ transmission_watch_directory }}:/watch:rw"
+      - "{{ transmission_config_directory }}:/config"
+      - "{{ downloads_root }}:/downloads"
+      - "{{ torrents_root }}:/watch"
     ports:
       - "9092:9091"
       - "51414:51413"
@@ -27,8 +55,56 @@
       PGID: "{{ transmission_group_id }}"
     restart_policy: unless-stopped
     memory: 1g
+  register: transmission_container
     labels:
       traefik.backend: "transmission"
       traefik.frontend.rule: "Host:transmission.{{ ansible_nas_domain }}"
       traefik.enable: "{{ transmission_available_externally }}"
       traefik.port: "9091"
+
+- name: Stop Transmission Container
+  docker_container:
+    name: transmission
+    state: stopped
+  when: transmission_container.changed
+
+- name: Enable Transmission User login
+  replace:
+    path: "{{ transmission_config_directory }}/settings.json"
+    regexp: '^\s+"rpc-authentication-required": false,$'
+    replace: '    "rpc-authentication-required": true,'
+  when: transmission_container.changed
+
+- name: Set Transmission Username
+  replace:
+    path: "{{ transmission_config_directory }}/settings.json"
+    regexp: '^\s+"rpc-username": "",$'
+    replace: '    "rpc-username": "admin",'
+  when: transmission_container.changed
+
+- name: Set Transmission Password
+  replace:
+    path: "{{ transmission_config_directory }}/settings.json"
+    regexp: '^\s+"rpc-password": "{1ddd3f1f6a71d655cde7767242a23a575b44c909n5YuRT\.f",$'
+    replace: '    "rpc-password": "admin",'
+  when: transmission_container.changed
+
+- name: Update Transmission download dir setting
+  replace:
+    path: "{{ transmission_config_directory }}/settings.json"
+    regexp: '^\s+"download-dir": "/downloads/complete",$'
+    replace: '    "download-dir": "/downloads/transmission/complete",'
+  when: transmission_container.changed
+
+- name: Update Transmission incomplete dir setting
+  replace:
+    path: "{{ transmission_config_directory }}/settings.json"
+    regexp: '^\s+"incomplete-dir": "/downloads/incomplete",$'
+    replace: '    "incomplete-dir": "/downloads/transmission/incomplete",'
+  when: transmission_container.changed
+
+- name: Start Transmission Container
+  docker_container:
+    name: transmission
+    state: started
+  when: transmission_container.changed

--- a/tasks/transmission.yml
+++ b/tasks/transmission.yml
@@ -39,8 +39,10 @@
 
 - name: Wait for transmission container startup
   pause:
-    seconds: 20
+    seconds: 60
   when: transmission_container.changed
+  tags:
+    - skip_ansible_lint
 
 # Brand new container requires a restart to correctly set
 # changed download paths. Probably due to settings.json
@@ -50,6 +52,8 @@
     name: transmission
     state: stopped
   when: transmission_container.changed
+  tags:
+    - skip_ansible_lint
 
 # Check for folders in the old location
 - name: Check for old transmission complete folder

--- a/tasks/transmission.yml
+++ b/tasks/transmission.yml
@@ -9,6 +9,48 @@
     - "{{ downloads_root }}/transmission"
     - "{{ torrents_root }}"
 
+- name: Transmission Docker Container
+  docker_container:
+    name: transmission
+    image: dperson/transmission
+    state: started
+    volumes:
+      - "{{ transmission_config_directory }}:/var/lib/transmission-daemon/info"
+      - "{{ downloads_root }}:/downloads"
+      - "{{ torrents_root }}:/watch"
+    ports:
+      - "9092:9091"
+      - "51414:51413"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      USERID: "{{ transmission_user_id }}"
+      GROUPID: "{{ transmission_group_id }}"
+      TR_DOWNLOAD_DIR: "/downloads/transmission/complete"
+      TR_INCOMPLETE_DIR: "/downloads/transmission/incomplete"
+      TR_WATCH_DIR: "/watch"
+    restart_policy: unless-stopped
+    memory: 1g
+  register: transmission_container
+    labels:
+      traefik.backend: "transmission"
+      traefik.frontend.rule: "Host:transmission.{{ ansible_nas_domain }}"
+      traefik.enable: "{{ transmission_available_externally }}"
+      traefik.port: "9091"
+
+- name: Wait for transmission container startup
+  pause:
+    seconds: 20
+  when: transmission_container.changed
+
+# Brand new container requires a restart to correctly set
+# changed download paths. Probably due to settings.json
+# being missing on container creation
+- name: Stop current transmission container
+  docker_container:
+    name: transmission
+    state: stopped
+  when: transmission_container.changed
+
 # Check for folders in the old location
 - name: Check for old transmission complete folder
   stat:
@@ -20,12 +62,6 @@
     path: "{{ downloads_root }}/incomplete"
   register: tif
 
-# - name: Delete current transmission container
-#   docker_container:
-#     name: transmission
-#     state: absent
-#   when: tcf.stat.isdir is defined and tcf.stat.isdir
-
 - name: Move transmission complete folder to new location
   command: mv "{{ downloads_root }}/complete" "{{ downloads_root }}/transmission"
   when: tcf.stat.isdir is defined and tcf.stat.isdir
@@ -36,75 +72,7 @@
   when: tif.stat.isdir is defined and tif.stat.isdir
   register: tif_move
 
-- name: Transmission Docker Container
-  docker_container:
-    name: transmission
-    image: linuxserver/transmission
-    pull: true
-    state: started
-    volumes:
-      - "{{ transmission_config_directory }}:/config"
-      - "{{ downloads_root }}:/downloads"
-      - "{{ torrents_root }}:/watch"
-    ports:
-      - "9092:9091"
-      - "51414:51413"
-    env:
-      TZ: "{{ ansible_nas_timezone }}"
-      PUID: "{{ transmission_user_id }}"
-      PGID: "{{ transmission_group_id }}"
-    restart_policy: unless-stopped
-    memory: 1g
-  register: transmission_container
-    labels:
-      traefik.backend: "transmission"
-      traefik.frontend.rule: "Host:transmission.{{ ansible_nas_domain }}"
-      traefik.enable: "{{ transmission_available_externally }}"
-      traefik.port: "9091"
-
-- name: Stop Transmission Container
-  docker_container:
-    name: transmission
-    state: stopped
-  when: transmission_container.changed
-
-- name: Enable Transmission User login
-  replace:
-    path: "{{ transmission_config_directory }}/settings.json"
-    regexp: '^\s+"rpc-authentication-required": false,$'
-    replace: '    "rpc-authentication-required": true,'
-  when: transmission_container.changed
-
-- name: Set Transmission Username
-  replace:
-    path: "{{ transmission_config_directory }}/settings.json"
-    regexp: '^\s+"rpc-username": "",$'
-    replace: '    "rpc-username": "admin",'
-  when: transmission_container.changed
-
-- name: Set Transmission Password
-  replace:
-    path: "{{ transmission_config_directory }}/settings.json"
-    regexp: '^\s+"rpc-password": "{1ddd3f1f6a71d655cde7767242a23a575b44c909n5YuRT\.f",$'
-    replace: '    "rpc-password": "admin",'
-  when: transmission_container.changed
-
-- name: Update Transmission download dir setting
-  replace:
-    path: "{{ transmission_config_directory }}/settings.json"
-    regexp: '^\s+"download-dir": "/downloads/complete",$'
-    replace: '    "download-dir": "/downloads/transmission/complete",'
-  when: transmission_container.changed
-
-- name: Update Transmission incomplete dir setting
-  replace:
-    path: "{{ transmission_config_directory }}/settings.json"
-    regexp: '^\s+"incomplete-dir": "/downloads/incomplete",$'
-    replace: '    "incomplete-dir": "/downloads/transmission/incomplete",'
-  when: transmission_container.changed
-
 - name: Start Transmission Container
   docker_container:
     name: transmission
     state: started
-  when: transmission_container.changed

--- a/tasks/transmission_with_openvpn.yml
+++ b/tasks/transmission_with_openvpn.yml
@@ -9,8 +9,8 @@
     # mode: 0755
   with_items:
     - "{{ transmission_config_directory }}"
-    - "{{ transmission_download_directory }}"
-    - "{{ transmission_watch_directory }}"
+    - "{{ downloads_root }}/transmission"
+    - "{{ torrents_root }}"
 
 - name: Transmission with VPN
   docker_container:
@@ -18,19 +18,19 @@
     image: haugene/transmission-openvpn
     pull: true
     volumes:
-      - "/etc/localtime:/etc/localtime:ro"
-      - "{{ transmission_download_directory }}:/storage/downloads:rw"
-      - "{{ transmission_config_directory }}:/config:rw"
-      - "{{ transmission_watch_directory }}:/storage/watch:rw"
+      - "{{ transmission_config_directory }}:/config"
+      - "{{ downloads_root }}:/downloads"
+      - "{{ torrents_root }}:/watch"
       - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
     ports:
       - "9091:9091"
       - "51413:51413"
     env:
       TRANSMISSION_HOME: /config
-      TRANSMISSION_DOWNLOAD_DIR: /storage/downloads/complete
-      TRANSMISSION_INCOMPLETE_DIR: /storage/downloads/incomplete
-      TRANSMISSION_WATCH_DIR: /storage/watch
+      TRANSMISSION_DOWNLOAD_DIR: /downloads/transmission/complete
+      TRANSMISSION_INCOMPLETE_DIR: /downloads/transmission/incomplete
+      TRANSMISSION_WATCH_DIR: /watch
       OPENVPN_PROVIDER: "{{ openvpn_provider }}"
       OPENVPN_USERNAME: "{{ openvpn_username }}"
       OPENVPN_PASSWORD: "{{ openvpn_password }}"

--- a/tasks/transmission_with_openvpn.yml
+++ b/tasks/transmission_with_openvpn.yml
@@ -50,3 +50,38 @@
       traefik.frontend.rule: "Host:transmission-openvpn.{{ ansible_nas_domain }}"
       traefik.enable: "{{ transmission_with_openvpn_available_externally }}"
       traefik.port: "9091"
+  register: transmission_openvpn_container
+
+- name: Stop current transmission container
+  docker_container:
+    name: transmission-openvpn
+    state: stopped
+  when: transmission_openvpn_container.changed
+  tags:
+    - skip_ansible_lint
+
+# Check for folders in the old location
+- name: Check for old transmission complete folder
+  stat:
+    path: "{{ downloads_root }}/complete"
+  register: tcf
+
+- name: Check for old transmission incomplete folder
+  stat:
+    path: "{{ downloads_root }}/incomplete"
+  register: tif
+
+- name: Move transmission complete folder to new location
+  command: mv "{{ downloads_root }}/complete" "{{ downloads_root }}/transmission"
+  when: tcf.stat.isdir is defined and tcf.stat.isdir
+  register: tcf_move
+
+- name: Move transmission incomplete folder to new location
+  command: mv "{{ downloads_root }}/incomplete" "{{ downloads_root }}/transmission"
+  when: tif.stat.isdir is defined and tif.stat.isdir
+  register: tif_move
+
+- name: Start Transmission OpenVPN Container
+  docker_container:
+    name: transmission-openvpn
+    state: started


### PR DESCRIPTION
Move transmission downloads directory one level down under /downloads.

This is a first and important step for enabling multiple download clients with proper integration with radarr, sonaar, etc.