### PR TITLE
First post-install instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 ![Ansible-NAS Logo](https://raw.githubusercontent.com/davestephens/ansible-nas/master/misc/ansible-nas.png "Ansible-NAS Logo")
 
-After getting burned by broken FreeNAS updates one too many times, I figured I could do a much better job myself using just a stock Ubuntu install, some clever Ansible config and a bunch of Docker containers. Ansible-NAS was born!
+After getting burned by broken FreeNAS updates one too many times, I figured I
+could do a much better job myself using just a stock Ubuntu install, some clever
+Ansible config and a bunch of Docker containers. Ansible-NAS was born!
 
 ## Features
 
@@ -20,7 +22,9 @@ After getting burned by broken FreeNAS updates one too many times, I figured I c
 
 ## Getting Started
 
-Head to [installation](installation.md) if you're ready to roll, or
-[testing](testing.md) if you want to spin up a test VM first. If this is all
-very confusing, there is also an [overview](overview.md) of the project and what
-is required for complete beginners.
+Head to [installation](installation.md) if you're ready to roll, or to
+[testing](testing.md) if you want to spin up a test Virtual Machine first. Once
+you're done, check out the [post-installation](post_installation.md) steps. 
+
+If this is all very confusing, there is also an [overview](overview.md) of the
+project and what is required for complete beginners.

--- a/docs/post_installation.md
+++ b/docs/post_installation.md
@@ -5,11 +5,14 @@ dashboard of your new NAS, because most of the applications included come with a
 web interface. Heimdall lets you create "apps" for them which appear as little
 icons on the screen. 
 
-To add applications to Heimdall, you'll need the IP address of your NAS. If you
-don't know the address for some reason and have not installed
-[Avahi](https://www.avahi.org/) for zero-configuration networking (mDNS), you
-can `ssh` into your NAS and type `ip a` to find it. The entry "link/ether",
-usually the second one after the loopback device, will show the address. 
+To add applications to Heimdall, you'll need the IP address of your NAS.  If you
+don't know it for some reason, you will have to look up using the console with
+`ip a`. The entry "link/ether", usually the second one after the loopback
+device, will show the address. Another alternative is to make sure
+[Avahi](https://www.avahi.org/) is installed for zero-configuration networking
+(mDNS). This will allow you to `ssh` into your NAS and with the extension
+`.local` to your machines name, such as `ssh tardis.local`. Then you can use the
+`ip a` command again.
 
 Next, you need the application's port, which you can look up in the [list of
 ports](application_ports.md). You can test the combination of address and port

--- a/docs/post_installation.md
+++ b/docs/post_installation.md
@@ -1,0 +1,26 @@
+So you've installed Ansible-NAS. Now what?
+
+The first thing to do is to configure [Heimdall](https://heimdall.site/) as the
+dashboard of your new NAS, because most of the applications included come with a
+web interface. Heimdall lets you create "apps" for them which appear as little
+icons on the screen. 
+
+To add applications to Heimdall, you'll need the IP address of your NAS. If you
+don't know the address for some reason and have not installed
+[Avahi](https://www.avahi.org/) for zero-configuration networking (mDNS), you
+can `ssh` into your NAS and type `ip a` to find it. The entry "link/ether",
+usually the second one after the loopback device, will show the address. 
+
+Next, you need the application's port, which you can look up in the [list of
+ports](application_ports.md). You can test the combination of address and port
+in your browser by typing them joined by a colon. For instance, for Glances on a
+machine with the IPv4 address 192.168.1.2, the full address would be
+`http://192.168.1.2:61208`. Once you are sure it works, use this address and
+port combination when creating the Heimdall icon.
+
+[Glances](https://nicolargo.github.io/glances/) and
+[Portainer](https://www.portainer.io/) are probably the two applications you
+want to add to Heimdall first, so you can see what is happening on the NAS.
+Note that Portainer will ask for your admin password. After that, it depends on
+what you have installed - see the listing for individual applications for more
+information.


### PR DESCRIPTION
Adds the first version of a text about what to do when installation was successful. A lot depends on what the user has chosen to include, but I'm figuring Heimdall should be the way to go one way or another.