### PR TITLE
Changing to Guacamole container with TOTP option

### DIFF
--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -206,6 +206,13 @@ cloudflare_email: dave@awesomedomain.com
 # Cloudflare 'Global API Key', can be found on the 'My Profile' page
 cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
 
+###
+### Guacamole
+###
+# If you enable the variable below, you can add TOTP 2-Factor authentication for all of your guacamole users.
+# Please read about this extension here: https://guacamole.apache.org/doc/gug/totp-auth.html
+enable_guacamole_totp: false
+
 ##################################################################
 ###### You shouldn't need to edit anything below this point ######
 ##################################################################
@@ -382,8 +389,6 @@ nginx_data_directory: "{{ docker_home }}/nginx"
 ###
 ### Guacamole
 ###
-guacamole_docker_image: guacamole/guacamole:0.9.14
-guacamole_guacd_docker_image: guacamole/guacd:0.9.14
 guacamole_data_directory: "{{ docker_home }}/guacamole"
 
 ###

--- a/tasks/guacamole.yml
+++ b/tasks/guacamole.yml
@@ -4,55 +4,46 @@
     path: "{{ item }}"
     state: directory
   with_items:
-    - "{{ guacamole_data_directory }}/mysql"
+    - "{{ guacamole_data_directory }}/config"
 
-- name: Copy Guacamole database init script
-  copy:
-    src: files/guacamole/initdb-0.9.14.sql
-    dest: "{{ guacamole_data_directory }}/initdb-0.9.14.sql"
-
-- name: Guacamole Mysql Docker Container
-  docker_container:
-    name: guacamole-mysql
-    image: mysql:5.7
-    pull: true
-    volumes:
-      - "{{ guacamole_data_directory }}/mysql:/var/lib/mysql:rw"
-      - "{{ guacamole_data_directory }}/initdb-0.9.14.sql:/docker-entrypoint-initdb.d/initdb-0.9.14.sql:ro"
-    env:
-      MYSQL_DATABASE: guacamole
-      MYSQL_USER: guacamole-user
-      MYSQL_PASSWORD: guacamole-pass
-      MYSQL_ROOT_PASSWORD: guacamole-secret
-    restart_policy: unless-stopped
-    memory: 1g
-
-- name: Guacamole guacd Container
-  docker_container:
-    name: guacamole-guacd
-    image: "{{ guacamole_guacd_docker_image }}"
-    pull: true
-    restart_policy: unless-stopped
-    memory: 1g
-
-- name: Guacamole guacamole Container
+- name: Guacamole Container (TOTP)
+  when: enable_guacamole_totp == true
   docker_container:
     name: guacamole
-    image: "{{ guacamole_docker_image }}"
+    image: oznu/guacamole
     pull: true
-    links:
-        - guacamole-mysql:mysql
-        - guacamole-guacd:guacd
     ports:
       - "8090:8080"
+    volumes:
+      - "{{ guacamole_data_directory }}/config:/config:rw"
     env:
-      MYSQL_DATABASE: guacamole
-      MYSQL_USER: guacamole-user
-      MYSQL_PASSWORD: guacamole-pass
+      EXTENSIONS: auth-totp
     labels:
       traefik.backend: "guacamole"
       traefik.frontend.rule: "Host:guacamole.{{ ansible_nas_domain }}"
       traefik.enable: "true"
       traefik.port: "8080"
     restart_policy: unless-stopped
-    memory: 1g
+  register: guac_result
+
+- name: Guacamole Container
+  when: enable_guacamole_totp == false
+  docker_container:
+    name: guacamole
+    image: oznu/guacamole
+    pull: true
+    ports:
+      - "8090:8080"
+    volumes:
+      - "{{ guacamole_data_directory }}/config:/config:rw"
+    labels:
+      traefik.backend: "guacamole"
+      traefik.frontend.rule: "Host:guacamole.{{ ansible_nas_domain }}"
+      traefik.enable: "true"
+      traefik.port: "8080"
+    restart_policy: unless-stopped
+
+- name: Restart Guacamole Container
+  when: guac_result.changed
+  command: docker restart guacamole
+  become: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -206,6 +206,13 @@ cloudflare_email: dave@awesomedomain.com
 # Cloudflare 'Global API Key', can be found on the 'My Profile' page
 cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
 
+###
+### Guacamole
+###
+# If you enable the variable below, you can add TOTP 2-Factor authentication for all of your guacamole users.
+# Please read about this extension here: https://guacamole.apache.org/doc/gug/totp-auth.html
+enable_guacamole_totp: false
+
 ##################################################################
 ###### You shouldn't need to edit anything below this point ######
 ##################################################################
@@ -382,8 +389,6 @@ nginx_data_directory: "{{ docker_home }}/nginx"
 ###
 ### Guacamole
 ###
-guacamole_docker_image: guacamole/guacamole:0.9.14
-guacamole_guacd_docker_image: guacamole/guacd:0.9.14
 guacamole_data_directory: "{{ docker_home }}/guacamole"
 
 ###


### PR DESCRIPTION
By setting enable_guacamole_totp to "true", the container will be set up with the extension and all users will have TOTP enforced on their accounts. Ansible also restarts the the container if it is rebuilt as this is required for the extension.