### PR TITLE
Add bitwarden service

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ just a stock Ubuntu install, some clever Ansible config and a bunch of Docker co
 ### Docker Containers Used
 
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
+* [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your dynamic IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies
 * [Duplicati](https://www.duplicati.com/) - for backing up your stuff

--- a/docs/applications/bitwarden.md
+++ b/docs/applications/bitwarden.md
@@ -1,0 +1,15 @@
+# Bitwarden(_rs) Password Management
+
+Homepage: [https://github.com/dani-garcia/bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs)
+Bitwarden: [https://bitwarden.com/](https://bitwarden.com/)
+
+This is a Bitwarden server API implementation written in Rust compatible with upstream Bitwarden clients*, perfect for self-hosted deployment where running the official resource-heavy service might not be ideal.
+
+## Usage
+
+Set `bitwarden_enabled: true` in your `group_vars/all.yml` file.
+
+## Specific Configuration
+
+Make sure you set your admin token! It is bitwarden_admin_token in `group_vars/all.yml` file. The string you put here will be the login to the admin section
+of your bitwarden installation (https://bitwarden.ansiblenasdomain.tld/admin). This token can be anything, but it's recommended to use a long, randomly generated string of characters, for example running: openssl rand -base64 48.

--- a/docs/applications/bitwarden.md
+++ b/docs/applications/bitwarden.md
@@ -11,5 +11,8 @@ Set `bitwarden_enabled: true` in your `group_vars/all.yml` file.
 
 ## Specific Configuration
 
-Make sure you set your admin token! It is bitwarden_admin_token in `group_vars/all.yml` file. The string you put here will be the login to the admin section
-of your bitwarden installation (https://bitwarden.ansiblenasdomain.tld/admin). This token can be anything, but it's recommended to use a long, randomly generated string of characters, for example running: openssl rand -base64 48.
+Make sure you set your admin token! It is bitwarden_admin_token in `group_vars/all.yml` file. The string you put here will be the login to the admin section of your bitwarden installation (https://bitwarden.ansiblenasdomain.tld/admin). This token can be anything, but it's recommended to use a long, randomly generated string of characters, for example running: openssl rand -base64 48.
+
+To create a user, you need to change a variable in ./tasks/bitwarden.yml. Set "SIGNUPS_ALLOWED" to "true", and reprovision the container. Once you have created your user, I would reccomend setting it to false and reprovisioning one more time.
+
+There is currently an issue with websockets and this configuration; traefik does not work correctly when enabled. If this issue gets resolved, I will update the file. Until that time, please note that synchronizations between your vault and browser extensions will not be instant. You will need to force a sync or wait on the scheduled sync (approx. 1h).

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -5,6 +5,8 @@ By default, applications can be found on the ports listed below.
 | Application     | Port   | Notes     |
 |-----------------|--------|-----------|
 | Couchpotato     | 5050   |           |
+| Bitwarden "hub" | 3012   | Web Not.  |
+| Bitwarden       | 19080  | HTTP      |
 | Duplicati       | 8200   |           |
 | Emby            | 8096   | HTTP      |
 | Emby            | 8920   | HTTPS     |

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -59,6 +59,8 @@ timemachine_enabled: false
 # IRC bouncer
 znc_enabled: false
 
+# Password Management
+bitwarden_enabled: false
 
 ###
 ### General
@@ -206,6 +208,14 @@ cloudflare_email: dave@awesomedomain.com
 
 # Cloudflare 'Global API Key', can be found on the 'My Profile' page
 cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
+
+###
+### Bitwarden
+###
+# Keep this token secret, this is password to access admin area of your server!
+# This token can be anything, but it's recommended to use a long, randomly generated string of characters,
+# for example running openssl rand -base64 48
+bitwarden_admin_token: qwertyuiop1234567890poiuytrewq0987654321
 
 ##################################################################
 ###### You shouldn't need to edit anything below this point ######
@@ -449,3 +459,8 @@ mymediaforalexa_data_directory: "{{ docker_home }}/mymediaforalexa"
 ### jackett
 ###
 jackett_data_directory: "{{ docker_home }}/jackett"
+
+###
+### bitwarden
+###
+bitwarden_data_directory: "{{ docker_home }}/bitwarden"

--- a/nas.yml
+++ b/nas.yml
@@ -138,3 +138,7 @@
   - import_tasks: tasks/jackett.yml
     when: (jackett_enabled | default(False))
     tags: jackett
+
+  - import_tasks: tasks/bitwarden.yml
+    when: (bitwarden_enabled | default(False))
+    tags: bitwarden

--- a/tasks/bitwarden.yml
+++ b/tasks/bitwarden.yml
@@ -19,15 +19,15 @@
       SIGNUPS_ALLOWED: "false"
       ADMIN_TOKEN: "{{ bitwarden_admin_token }}"
       LOG_FILE: "/data/bitwarden.log"
+      WEBSOCKET_ENABLED: "true"
     labels:
       traefik.backend: "bitwarden"
       traefik.web.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }}"
       traefik.enable: "true"
       traefik.web.port: "80"
-      #traefik.web.frontend.headers.customFrameOptionsValue: "ALLOW-FROM http://{{ ansible_nas_domain }}"
-      #traefik.web.frontend.headers.customFrameOptionsValue: "ALLOW-FROM https://{{ ansible_nas_domain }}"
-      #traefik.hub.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }};Path:/notifications/hub"
-      #traefik.hub.port: "3012"
+      traefik.hub.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }};Path:/notifications/hub"
+      traefik.hub.port: "3012"
+      traefik.hub.protocol: "ws"
     restart_policy: unless-stopped
     #memory: 1g
 

--- a/tasks/bitwarden.yml
+++ b/tasks/bitwarden.yml
@@ -17,7 +17,7 @@
       - "{{ bitwarden_data_directory }}:/data:rw"
     env:
       SIGNUPS_ALLOWED: "false"
-      ADMIN_TOKEN: "{{ bitwarden_admin_token }}" 
+      ADMIN_TOKEN: "{{ bitwarden_admin_token }}"
       LOG_FILE: "/data/bitwarden.log"
     labels:
       traefik.backend: "bitwarden"

--- a/tasks/bitwarden.yml
+++ b/tasks/bitwarden.yml
@@ -11,7 +11,7 @@
     image: mprasil/bitwarden:latest
     pull: true
     ports:
-      #- "19080:80"
+      - "19080:80"
       - "3012:3012"
     volumes:
       - "{{ bitwarden_data_directory }}:/data:rw"

--- a/tasks/bitwarden.yml
+++ b/tasks/bitwarden.yml
@@ -26,9 +26,8 @@
       traefik.web.port: "80"
       #traefik.web.frontend.headers.customFrameOptionsValue: "ALLOW-FROM http://{{ ansible_nas_domain }}"
       #traefik.web.frontend.headers.customFrameOptionsValue: "ALLOW-FROM https://{{ ansible_nas_domain }}"
-      #traefik.web.frontend.headers.SSLRedirect: "true"
-      traefik.hub.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }};Path:/notifications/hub"
-      traefik.hub.port: "3012"
+      #traefik.hub.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }};Path:/notifications/hub"
+      #traefik.hub.port: "3012"
     restart_policy: unless-stopped
     #memory: 1g
 
@@ -39,3 +38,4 @@
     pull: true
     restart_policy: unless-stopped
     volumes_from: bitwarden
+    memory: 1g

--- a/tasks/bitwarden.yml
+++ b/tasks/bitwarden.yml
@@ -1,0 +1,41 @@
+- name: Create Bitwarden Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ bitwarden_data_directory }}"
+
+- name: Bitwarden Docker Container
+  docker_container:
+    name: bitwarden
+    image: mprasil/bitwarden:latest
+    pull: true
+    ports:
+      #- "19080:80"
+      - "3012:3012"
+    volumes:
+      - "{{ bitwarden_data_directory }}:/data:rw"
+    env:
+      SIGNUPS_ALLOWED: "false"
+      ADMIN_TOKEN: "{{ bitwarden_admin_token }}" 
+      LOG_FILE: "/data/bitwarden.log"
+    labels:
+      traefik.backend: "bitwarden"
+      traefik.web.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }}"
+      traefik.enable: "true"
+      traefik.web.port: "80"
+      #traefik.web.frontend.headers.customFrameOptionsValue: "ALLOW-FROM http://{{ ansible_nas_domain }}"
+      #traefik.web.frontend.headers.customFrameOptionsValue: "ALLOW-FROM https://{{ ansible_nas_domain }}"
+      #traefik.web.frontend.headers.SSLRedirect: "true"
+      traefik.hub.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }};Path:/notifications/hub"
+      traefik.hub.port: "3012"
+    restart_policy: unless-stopped
+    #memory: 1g
+
+- name: Bitwarden Backup Container
+  docker_container:
+    name: bitwarden-backup
+    image: bruceforce/bw_backup:latest
+    pull: true
+    restart_policy: unless-stopped
+    volumes_from: bitwarden

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -180,6 +180,7 @@ onDemand = false # create certificate when container is created
 
   # we request a certificate for everything, because why not.
   sans = ["airsonic.{{ ansible_nas_domain }}",
+          "bitwarden.{{ ansible_nas_domain }}",
           "couchpotato.{{ ansible_nas_domain }}",
           "duplicati.{{ ansible_nas_domain }}",
           "emby.{{ ansible_nas_domain }}",

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -59,6 +59,9 @@ timemachine_enabled: false
 # IRC bouncer
 znc_enabled: false
 
+# Password Management
+bitwarden_enabled: false
+
 ###
 ### General
 ###
@@ -206,6 +209,14 @@ cloudflare_email: dave@awesomedomain.com
 
 # Cloudflare 'Global API Key', can be found on the 'My Profile' page
 cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
+
+###
+### Bitwarden
+###
+# Keep this token secret, this is password to access admin area of your server!
+# This token can be anything, but it's recommended to use a long, randomly generated string of characters,
+# for example running openssl rand -base64 48
+bitwarden_admin_token: qwertyuiop1234567890poiuytrewq0987654321
 
 ##################################################################
 ###### You shouldn't need to edit anything below this point ######
@@ -449,3 +460,8 @@ mymediaforalexa_data_directory: "{{ docker_home }}/mymediaforalexa"
 ### jackett
 ###
 jackett_data_directory: "{{ docker_home }}/jackett"
+
+###
+### bitwarden
+###
+bitwarden_data_directory: "{{ docker_home }}/bitwarden"


### PR DESCRIPTION
Bitwarden is a password management tool, similar to LastPass.

This version of bitwarden is in a single docker container as opposed to the official version which creates something like 6 containers. It also includes a backup tool that will automatically create a backup at 5 a.m. every day. This tool can be configured as well.