### PR TITLE
Add permissions parameters for Plex and Emby

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,10 @@ Assuming that your Ubuntu system disk is separate from your storage (it should b
 
 ## Requirements
 
-<<<<<<< HEAD
-* Ansible NAS targets the latest Ubuntu LTS release, which is currently Ubuntu Server 18.04.2 LTS. 
-* You can run Ansible-NAS on whatever you like, read the docs for more info. I use an HP Microserver.
-=======
-Ansible NAS should work on any recent Ubuntu box. Development is done on Ubuntu
-Server 18.04.1 LTS running on an HP Microserver.
->>>>>>> Added permissions parameters to Plex and Emby
+* Ansible NAS targets the latest Ubuntu LTS release, which is currently Ubuntu
+  Server 18.04.2 LTS. 
+* You can run Ansible-NAS on whatever you like, read the docs for more info. I
+  use an HP Microserver.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Build Status](https://img.shields.io/travis/com/davestephens/ansible-nas.svg?logo=travis&style=flat-square)](https://travis-ci.com/davestephens/ansible-nas) [![Gitter chat](https://img.shields.io/gitter/room/ansible-nas/chat.svg?logo=gitter&style=flat-square)](https://gitter.im/Ansible-NAS/Chat) [![license](https://img.shields.io/github/license/DAVFoundation/api_doc.svg?style=flat-square)](https://github.com/davestephens/ansible-nas/blob/master/LICENSE)
 
-After getting burned by broken FreeNAS updates one too many times, I figured I could do a much better job myself using
-just a stock Ubuntu install, some clever Ansible config and a bunch of Docker containers.
+After getting burned by broken FreeNAS updates one too many times, I figured I
+could do a much better job myself using just a stock Ubuntu install, some clever
+Ansible config and a bunch of Docker containers.
 
 ## What This Sets Up
 
@@ -60,19 +61,27 @@ just a stock Ubuntu install, some clever Ansible config and a bunch of Docker co
 
 ## What This Could Do
 
-Ansible-NAS can run anything that's in a Docker image, which is why Portainer is included. A NAS configuration is a pretty personal thing based on what you download, what media you view, how many photos you take...so it's difficult to please everyone.
+Ansible-NAS can run anything that's in a Docker image, which is why Portainer is
+included. A NAS configuration is a pretty personal thing based on what you
+download, what media you view, how many photos you take...so it's difficult to
+please everyone.
 
-That said, if specific functionality you want isn't included and you think others could benefit, add it and raise a PR!
+That said, if specific functionality you want isn't included and you think
+others could benefit, add it and raise a PR!
 
 ## What This Doesn't Do
 
-Ansible NAS doesn't set up your disk partitions, primarily because getting it wrong can be incredibly destructive.
-That aside, configuring partitions is usually a one-time (or very infrequent) event, so there's not much to be
-gained by automating it.
+Ansible NAS doesn't set up your disk partitions, primarily because getting it
+wrong can be incredibly destructive.  That aside, configuring partitions is
+usually a one-time (or very infrequent) event, so there's not much to be gained
+by automating it.
 
 ## Quick Start
 
-:skull: Before running anything, check out the playbook and understand what it does. Run it against a VM and make sure you're happy. ***Do not*** blindly download code from the internet and trust that it's going to work as you expect. :skull: 
+:skull: Before running anything, check out the playbook and understand what it
+does. Run it against a VM and make sure you're happy. ***Do not*** blindly
+download code from the internet and trust that it's going to work as you expect.
+:skull: 
 
 1. Enable the Ubuntu Universe repository: `sudo add-apt-repository universe`
 2. Install Ansible: `sudo apt install ansible`
@@ -87,7 +96,8 @@ gained by automating it.
 
 ## Documentation
 
-You can read the docs [here](https://davestephens.github.io/ansible-nas). PRs for more documentation always welcome!
+You can read the docs [here](https://davestephens.github.io/ansible-nas). PRs
+for more documentation always welcome!
 
 ## Migrating from FreeNAS
 
@@ -102,8 +112,13 @@ Assuming that your Ubuntu system disk is separate from your storage (it should b
 
 ## Requirements
 
+<<<<<<< HEAD
 * Ansible NAS targets the latest Ubuntu LTS release, which is currently Ubuntu Server 18.04.2 LTS. 
 * You can run Ansible-NAS on whatever you like, read the docs for more info. I use an HP Microserver.
+=======
+Ansible NAS should work on any recent Ubuntu box. Development is done on Ubuntu
+Server 18.04.1 LTS running on an HP Microserver.
+>>>>>>> Added permissions parameters to Plex and Emby
 
 ## Getting Help
 

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -290,7 +290,9 @@ transmission_local_network: "192.168.1.0/24"
 plex_available_externally: "false"
 plex_config_directory: "{{ docker_home }}/plex/config"
 plex_movies_directory: "{{ movies_root }}"
+plex_movies_permissions: "ro"
 plex_tv_directory: "{{ tv_root }}"
+plex_tv_permissions: "ro"
 plex_user_id: 0
 plex_group_id: 0
 
@@ -300,7 +302,9 @@ plex_group_id: 0
 emby_available_externally: "false"
 emby_config_directory: "{{ docker_home }}/emby/config"
 emby_movies_directory: "{{ movies_root }}"
+emby_movies_permissions: "ro"
 emby_tv_directory: "{{ tv_root }}"
+emby_tv_permissions: "ro"
 emby_user_id: 0
 emby_group_id: 0
 

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -287,6 +287,8 @@ transmission_local_network: "192.168.1.0/24"
 ###
 ### Plex
 ###
+# If you're paranoid, set permissions to "ro" so Plex won't ever be able to
+# delete your files
 plex_available_externally: "false"
 plex_config_directory: "{{ docker_home }}/plex/config"
 plex_movies_directory: "{{ movies_root }}"
@@ -299,6 +301,8 @@ plex_group_id: 0
 ###
 ### Emby
 ###
+# If you're paranoid, set permissions to "ro" so Emby won't ever be able to
+# delete your files
 emby_available_externally: "false"
 emby_config_directory: "{{ docker_home }}/emby/config"
 emby_movies_directory: "{{ movies_root }}"

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -290,9 +290,9 @@ transmission_local_network: "192.168.1.0/24"
 plex_available_externally: "false"
 plex_config_directory: "{{ docker_home }}/plex/config"
 plex_movies_directory: "{{ movies_root }}"
-plex_movies_permissions: "ro"
+plex_movies_permissions: "rw"
 plex_tv_directory: "{{ tv_root }}"
-plex_tv_permissions: "ro"
+plex_tv_permissions: "rw"
 plex_user_id: 0
 plex_group_id: 0
 
@@ -302,9 +302,9 @@ plex_group_id: 0
 emby_available_externally: "false"
 emby_config_directory: "{{ docker_home }}/emby/config"
 emby_movies_directory: "{{ movies_root }}"
-emby_movies_permissions: "ro"
+emby_movies_permissions: "rw"
 emby_tv_directory: "{{ tv_root }}"
-emby_tv_permissions: "ro"
+emby_tv_permissions: "rw"
 emby_user_id: 0
 emby_group_id: 0
 

--- a/tasks/emby.yml
+++ b/tasks/emby.yml
@@ -12,8 +12,8 @@
     pull: true
     volumes:
       - "{{ emby_config_directory }}:/config:rw"
-      - "{{ emby_movies_directory }}:/movies:rw"
-      - "{{ emby_tv_directory }}:/tv:rw"
+      - "{{ emby_movies_directory }}:/movies:{{ emby_movies_permissions }}"
+      - "{{ emby_tv_directory }}:/tv:{{ emby_tv_permissions }}"
     ports:
       - "8096:8096" # HTTP port
       - "8920:8920" # HTTPS port

--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -13,8 +13,8 @@
     pull: true
     volumes:
       - "{{ plex_config_directory }}:/config:rw"
-      - "{{ plex_movies_directory }}:/movies:rw"
-      - "{{ plex_tv_directory }}:/tv:rw"
+      - "{{ plex_movies_directory }}:/movies:{{ plex_movies_permissions }}"
+      - "{{ plex_tv_directory }}:/tv:{{ plex_tv_permissions }}"
     network_mode: "host"
     env:
       TZ: "{{ ansible_nas_timezone }}"


### PR DESCRIPTION
User can now set parameters to decide if their Plex and/or Emby apps should consider the TV and movies folders as read-only or read-write (see discussion at #69). Default is read-only as best practice. 

(Apols, vagrant test won't work on my system (see #74), so this might need further testing by somebody who actually knows what he's doing.)