### PR TITLE
Fix typo in local link to ZFS intro

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,4 @@ you're done, check out the [post-installation](post_installation.md) steps.
 
 If this is all very confusing, there is also an [overview](overview.md) of the
 project and what is required for complete beginners. If you're only confused
-abot ZFS, we'll help you [get started](zfs_overview.md) as well.
+abot ZFS, we'll help you [get started](zfs/zfs_overview.md) as well.


### PR DESCRIPTION
Sorry, the index.md file in docs is missing the correct link to the ZFS intro file (missing zfs folder).