### PR TITLE
Make bitwarden_rs work with Traefik

### DIFF
--- a/tasks/bitwarden.yml
+++ b/tasks/bitwarden.yml
@@ -21,7 +21,6 @@
       LOG_FILE: "/data/bitwarden.log"
       WEBSOCKET_ENABLED: "true"
     labels:
-      traefik.backend: "bitwarden"
       traefik.web.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }}"
       traefik.enable: "{{ bitwarden_available_externally }}"
       traefik.web.port: "80"


### PR DESCRIPTION
The bitwarden_rs container didn't work with Traefik. Removing the `traefik.backend` label does the trick, as it now creates the backend backend-bitwarden-hub for websockets and the backend backend-bitwarden-web for http. See https://github.com/dani-garcia/bitwarden_rs/issues/453