### PR TITLE
Changed ansible-nas user to use "nologin" shell

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -12,3 +12,4 @@
     update_password: on_create
     create_home: no
     group: ansible-nas
+    shell: /usr/sbin/nologin


### PR DESCRIPTION
For security, in the event anyone gives the ansible-nas user a password (not sure why they would), we should probably set the shell to /usr/sbin/nologin. Probably not a big deal but doesn't hurt either. I did this so I thought I'd share.