### PR TITLE
traefik networking to host mode

### DIFF
--- a/tasks/traefik.yml
+++ b/tasks/traefik.yml
@@ -26,10 +26,7 @@
     name: traefik
     image: "{{ traefik_docker_image }}"
     pull: true
-    ports:
-      - "80:80"
-      - "443:443"
-      - "8083:8083"
+    network_mode: host
     volumes:
       - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"


### PR DESCRIPTION
With traefik configured as it is now, it does not work with containers using "host" networking. This includes glances, emby, plex, tautilli, and others. Nonetheless, some of these include an optional "available_externally" flag and traefik labels... but they don't work. This pull request changes traefik to use host networking as well, which gives it access to all of the containers on the host and on the docker bridge network.