### PR TITLE
Separate config/logs and data directories for Time Machine container 

### DIFF
--- a/docs/applications/timemachine.md
+++ b/docs/applications/timemachine.md
@@ -14,6 +14,8 @@ Set `timemachine_enabled: true` in your `group_vars/all.yml` file.
 <dl>
   <dt><strong>timemachine_data_directory</strong></dt>
   <dd>The absolute path on Ansible NAS where the backup files will be stored</dd>
+  <dt><strong>timemachine_log_directory</strong></dt>
+  <dd>The absolute path on Ansible NAS where the log files will be stored</dd>
   <dt><strong>timemachine_volume_size_limit</strong></dt>
   <dd>The maximum amount of space Time Machine can use for the backups in units of MiB.  Set it to 0 for no limit.</dd>
   <dt><strong>timemachine_share_name</strong></dt>

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -497,7 +497,8 @@ watchtower_command: "--schedule '{{ watchtower_cron_schedule }}' --debug"
 ###
 ### Time Machine
 ###
-timemachine_data_directory: "{{ docker_home }}/timemachine"
+timemachine_data_directory: "{{ docker_home }}/timemachine/data/"
+timemachine_log_directory: "{{ docker_home }}/timemachine/logs/"
 timemachine_volume_size_limit: 0
 timemachine_password: timemachine
 timemachine_share_name: TimeMachine

--- a/tasks/timemachine.yml
+++ b/tasks/timemachine.yml
@@ -17,8 +17,8 @@
       SHARE_NAME: "{{ timemachine_share_name }}"
       LOG_LEVEL: "{{ timemachine_log_level }}"
     volumes:
-      - "{{ timemachine_data_directory }}/data:/opt/timemachine"
-      - "{{ timemachine_data_directory }}/logs:/var/log/supervisor"
+      - "{{ timemachine_data_directory }}:/opt/timemachine"
+      - "{{ timemachine_log_directory }}:/var/log/supervisor"
       - "/var/run/dbus:/var/run/dbus"
     network_mode: host
     restart_policy: unless-stopped


### PR DESCRIPTION
Split the directories for the timemachine container in two, making it
possible to save data on a different drive than logs.
Fixes #105