### PR TITLE
Fix traefik v1.7

### DIFF
--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -274,7 +274,7 @@ samba_netbios_name: "{{ ansible_nas_hostname }}"
 ###
 ### Traefik
 ###
-traefik_docker_image: traefik:latest
+traefik_docker_image: traefik:v1.7
 traefik_data_directory: "{{ docker_home }}/traefik"
 traefik_debug: "false"
 

--- a/tasks/traefik.yml
+++ b/tasks/traefik.yml
@@ -9,7 +9,7 @@
     name: letsencrypt-nginx-proxy-companion
     state: absent
 
-- name: Create Trafik Directories
+- name: Create Traefik Directories
   file:
     path: "{{ item }}"
     state: directory


### PR DESCRIPTION
The `traefik:latest` tag pulled in Traefik 2.0 for me today, which resulted in a failed Traefik configuration because it has breaking changes in the configuration file format. This PR fixes this by specifying `traefik:v1.7` for the docker image.