### PR TITLE
"Permission share dirirectories" – file: state: directory

### DIFF
--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -47,6 +47,7 @@
 - name: "Permission share directories"
   file:
     path: "{{ item.path }}"
+    state: directory
     owner: ansible-nas
     group: ansible-nas
     mode: "u=rwX,g=rwX,o=rX"


### PR DESCRIPTION
If you disable the bertvv.samba role (e.g. because you only want to use NFS, and not Samba), then general.yml fails in the "Permisison share directories" because they were not created. But this task specification can just require that they should be directories, and then it will make sure to create them if they do not exist, avoiding a "file/directory not found" error.