### PR TITLE
Add Step Certificates CA and ACME server

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Ansible config and a bunch of Docker containers.
 * A backup tool - allows scheduled backups to Amazon S3, OneDrive, Dropbox etc
 * An IRC bouncer and web-based client
 * Source control with Gitea
-* SSL secured external access to applications via Traefik
+* SSL secured external access to applications via Traefik and Let's Encrypt or Step Certificates
 * A Docker host with Portainer for image and container management
 * An automatic dynamic DNS updater if you use Cloudflare to host your domain DNS
 * A Personal finance manager
@@ -66,6 +66,7 @@ Ansible config and a bunch of Docker containers.
 * [Radarr](https://radarr.video/) - for organising and downloading movies
 * [Sickchill](https://sickchill.github.io/) - for managing TV episodes
 * [Sonarr](https://sonarr.tv/) - for downloading and managing TV episodes
+* [Step Certificates](https://smallstep.com/certificates/) - A private certificate authority (CA) and ACME server for secure automated certificate management
 * [Tautulli](http://tautulli.com/) - Monitor Your Plex Media Server
 * [Telegraf](https://github.com/influxdata/telegraf) - Metrics collection agent
 * [The Lounge](https://thelounge.chat) - Web based always-on IRC client

--- a/docs/applications/step-ca.md
+++ b/docs/applications/step-ca.md
@@ -40,4 +40,4 @@ sudo step certificate install --all .step/certs/root_ca.crt
 ## Step Certificates as a CA and ACME server for Traefik
 If Step Certificates is enabled, Traefik will use it as a CA and ACME server instead of Let's Encrypt.
 
-This setup requires that you have a local DNS server running that resolves every possible subdomain `*.{{ ansible_nas_domain }}` to the IP address of `{{ ansible_nas_domain }}`. This essentially mimics Cloudflare's wildcard DNS entries, but for your local domain.
+This setup requires that you have a local DNS server running that resolves every possible subdomain `*.{{ ansible_nas_domain }}` to the IP address of `{{ ansible_nas_domain }}`. For instance, if you are running the OPNsense operating system on your router and are using Unbound DNS, go to **Services / Unbound DNS / Overrides** and add an override with host `*`, domain `{{ ansible_nas_domain }}`, type `A or AAA (IPv4 or IPv6 address)` and the IP address of your Ansible-NAS machine. This essentially mimics Cloudflare's wildcard DNS entries, but for your local domain.

--- a/docs/applications/step-ca.md
+++ b/docs/applications/step-ca.md
@@ -14,8 +14,7 @@ Set `stepca_enabled: true` in your `group_vars/all.yml` file.
 
 Make sure you change the step-ca password. Step Certificates uses this to encrypt keys for all your certificates! It is `stepca_password` in your `group_vars/all.yml` file. This password can be anything, but it's recommended to use a long, randomly generated string of characters, for example running `openssl rand -base64 48`.
 
-The certificate authority will also have to be initialized first. This can be done by setting `stepca_init: true` in your `group_vars/all.yml` file and then running `ansible-playbook -i inventory nas.yml -b -K -t stepca`. Once you have initialized the CA, set the `stepca_init` varuable to false.
+The certificate authority will also have to be initialized first. This can be done by setting `stepca_init: true` in your `group_vars/all.yml` file and then running `ansible-playbook -i inventory nas.yml -b -K -t stepca`. Once you have initialized the CA, set the `stepca_init` variable to false.
 
-
-
-
+## Step Certificates as a CA for Traefik
+When your `group_vars/all.yml` file contains `stepca_enabled: true`, Traefik will use Step Certificates as a CA instead of Let's Encrypt for your TLS certificate.

--- a/docs/applications/step-ca.md
+++ b/docs/applications/step-ca.md
@@ -29,7 +29,7 @@ Then on your Linux desktop install the [step-cli](https://github.com/smallstep/c
 step ca bootstrap --fingerprint $FP --ca-url $CA
 ```
 
-Use the fingerprint instead of `$FP` and the URI of your CA instead of `$CA`: `{{ ansible_nas_domain }}:8443`. This downloads your CA's root certificate. Then [install](https://smallstep.com/docs/cli/certificate/install/) it system-wide with:
+Use the fingerprint instead of `$FP` and the URI of your CA instead of `$CA`: `stepca.{{ ansible_nas_domain }}:8443`. This downloads your CA's root certificate. Then [install](https://smallstep.com/docs/cli/certificate/install/) it system-wide with:
 
 ```
 sudo step certificate install --all .step/certs/root_ca.crt

--- a/docs/applications/step-ca.md
+++ b/docs/applications/step-ca.md
@@ -14,8 +14,6 @@ Set `stepca_enabled: true` in your `group_vars/all.yml` file.
 
 Make sure you change the step-ca password. Step Certificates uses this to encrypt keys for all your certificates! It is `stepca_password` in your `group_vars/all.yml` file. This password can be anything, but it's recommended to use a long, randomly generated string of characters, for example running `openssl rand -base64 48`.
 
-The certificate authority will also have to be initialized first. This can be done by setting `stepca_init: true` in your `group_vars/all.yml` file and then running `ansible-playbook -i inventory nas.yml -b -K -t stepca`. Once you have initialized the CA, set the `stepca_init` variable to false.
-
 ## Add your root certificate to your clients
 When using certificates signed by your own CA, you need to add the CA's root certificate to the trusted root store of each of your devices.
 

--- a/docs/applications/step-ca.md
+++ b/docs/applications/step-ca.md
@@ -1,0 +1,21 @@
+# Step Certificates
+
+Homepage: [https://smallstep.com/certificates/](https://smallstep.com/certificates/)
+
+
+The open source Step Certificates project provides the infrastructure, automations, and workflows to securely create and operate a private certificate authority. Step Certificates makes it easy for developers, operators and security teams to manage certificates for production workloads.
+
+
+## Usage
+
+Set `stepca_enabled: true` in your `group_vars/all.yml` file.
+
+## Initial configuration
+
+Make sure you change the step-ca password. Step Certificates uses this to encrypt keys for all your certificates! It is `stepca_password` in your `group_vars/all.yml` file. This password can be anything, but it's recommended to use a long, randomly generated string of characters, for example running `openssl rand -base64 48`.
+
+The certificate authority will also have to be initialized first. This can be done by setting `stepca_init: true` in your `group_vars/all.yml` file and then running `ansible-playbook -i inventory nas.yml -b -K -t stepca`. Once you have initialized the CA, set the `stepca_init` varuable to false.
+
+
+
+

--- a/docs/applications/step-ca.md
+++ b/docs/applications/step-ca.md
@@ -31,7 +31,7 @@ Then on your Linux desktop install the [step-cli](https://github.com/smallstep/c
 step ca bootstrap --fingerprint $FP --ca-url $CA
 ```
 
-Use the fingerprint instead of `$FP` and the URI of your CA instead of `$CA`: `{{ ansible_nas_domain }}:8443`. This downloads your CA's root certificate. Then install it system-wide with:
+Use the fingerprint instead of `$FP` and the URI of your CA instead of `$CA`: `{{ ansible_nas_domain }}:8443`. This downloads your CA's root certificate. Then [install](https://smallstep.com/docs/cli/certificate/install/) it system-wide with:
 
 ```
 sudo step certificate install --all .step/certs/root_ca.crt

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -2,51 +2,52 @@
 
 By default, applications can be found on the ports listed below.
 
-| Application     | Port   | Notes     |
-|-----------------|--------|-----------|
-| Airsonic        | 4040   |           |
-| Bazarr          | 6767   |           |
-| Bitwarden "hub" | 3012   | Web Not.  |
-| Bitwarden       | 19080  | HTTP      |
-| Calibre         | 8084   | HTTP      |
-| Cloud Commander | 7373   |           |
-| Couchpotato     | 5050   |           |
-| Duplicati       | 8200   |           |
-| Emby            | 8096   | HTTP      |
-| Emby            | 8920   | HTTPS     |
-| Firefly III     | 8066   |           |
-| get_iplayer     | 8182   |           |
-| Gitea           | 3001   | Web       |
-| Gitea           | 222    | SSH       |
-| Glances         | 61208  | SSH       |
-| Grafana         | 3000   |           |
-| Guacamole       | 8090   |           |
-| Heimdall        | 10080  |           |
-| Home Assistant  | 8123   |           |
-| Jackett         | 9117   |           |
-| Jellyfin        | 8896   | HTTP      |
-| Jellyfin        | 8928   | HTTPS     |
-| MiniDLNA        | 8201   |           |
-| Miniflux        | 8070   |           |
-| Mosquitto       | 1883   | MQTT      |
-| Mosquitto       | 9001   | Websocket |
-| MyMediaForAlexa | 52051  |           |
-| Netdata         | 19999  |           |
-| Nextcloud       | 8080   |           |
-| NZBGet          | 6789   |           |
-| openHAB         | 7777   | HTTP      |
-| openHAB         | 7778   | HTTPS     |
-| Plex            | 32400  |           |
-| Portainer       | 9000   |           |
-| pyload          | 8000   |           |
-| Radarr          | 7878   |           |
-| Sickchill       | 8081   |           |
-| Sonarr          | 8989   |           |
-| Tautulli        | 8181   |           |
-| The Lounge      | 9000   |           |
-| Time Machine    | 10445  | SMB       |
-| Traefik         | 8083   |           |
-| Transmission    | 9091   | with VPN  |
-| Transmission    | 9092   |           |
-| Wallabag        | 7780   |           |
-| ZNC             | 6677   |           |
+| Application       | Port   | Notes     |
+|-------------------|--------|-----------|
+| Airsonic          | 4040   |           |
+| Bazarr            | 6767   |           |
+| Bitwarden "hub"   | 3012   | Web Not.  |
+| Bitwarden         | 19080  | HTTP      |
+| Calibre           | 8084   | HTTP      |
+| Cloud Commander   | 7373   |           |
+| Couchpotato       | 5050   |           |
+| Duplicati         | 8200   |           |
+| Emby              | 8096   | HTTP      |
+| Emby              | 8920   | HTTPS     |
+| Firefly III       | 8066   |           |
+| get_iplayer       | 8182   |           |
+| Gitea             | 3001   | Web       |
+| Gitea             | 222    | SSH       |
+| Glances           | 61208  | SSH       |
+| Grafana           | 3000   |           |
+| Guacamole         | 8090   |           |
+| Heimdall          | 10080  |           |
+| Home Assistant    | 8123   |           |
+| Jackett           | 9117   |           |
+| Jellyfin          | 8896   | HTTP      |
+| Jellyfin          | 8928   | HTTPS     |
+| MiniDLNA          | 8201   |           |
+| Miniflux          | 8070   |           |
+| Mosquitto         | 1883   | MQTT      |
+| Mosquitto         | 9001   | Websocket |
+| MyMediaForAlexa   | 52051  |           |
+| Netdata           | 19999  |           |
+| Nextcloud         | 8080   |           |
+| NZBGet            | 6789   |           |
+| openHAB           | 7777   | HTTP      |
+| openHAB           | 7778   | HTTPS     |
+| Plex              | 32400  |           |
+| Portainer         | 9000   |           |
+| pyload            | 8000   |           |
+| Radarr            | 7878   |           |
+| Sickchill         | 8081   |           |
+| Sonarr            | 8989   |           |
+| Step Certificates | 8443   | HTTPS     |
+| Tautulli          | 8181   |           |
+| The Lounge        | 9000   |           |
+| Time Machine      | 10445  | SMB       |
+| Traefik           | 8083   |           |
+| Transmission      | 9091   | with VPN  |
+| Transmission      | 9092   |           |
+| Wallabag          | 7780   |           |
+| ZNC               | 6677   |           |

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -325,11 +325,6 @@ stepca_directory: "{{ docker_home }}/stepca"
 # for example running openssl rand -base64 48
 stepca_password: qwertyuiop1234567890poiuytrewq0987654321
 
-# To initialize your CA set this to "true" and run the ansible-nas playbook.
-# Target just Step Certificates by running: ansible-playbook -i inventory nas.yml -b -K -t stepca 
-# Once you have initialized the CA, set to "false".
-stepca_init: false
-
 ###
 ### Heimdall
 ###

--- a/group_vars/all.yml.dist
+++ b/group_vars/all.yml.dist
@@ -10,6 +10,9 @@
 # settings.
 traefik_enabled: false
 
+# Private certificate authority (CA)
+stepca_enabled: false
+
 # Downloading
 # If you plan to use Transmission with OpenVPN, you'll need to copy group_vars/vpn_credentials.yml.dist
 # to group_vars/vpn_credentials.yml, then update it with your own settings.
@@ -307,6 +310,22 @@ samba_netbios_name: "{{ ansible_nas_hostname }}"
 traefik_docker_image: traefik:v1.7
 traefik_data_directory: "{{ docker_home }}/traefik"
 traefik_debug: "false"
+
+###
+### Step Certificates
+###
+stepca_available_externally: "false"
+stepca_directory: "{{ docker_home }}/stepca"
+
+# Keep this password secret, this is used to encrypt keys for all your certificates. It is needed when the CA (re)starts.
+# This password can be anything, but it's recommended to use a long, randomly generated string of characters,
+# for example running openssl rand -base64 48
+stepca_password: qwertyuiop1234567890poiuytrewq0987654321
+
+# To initialize your CA set this to "true" and run the ansible-nas playbook.
+# Target just Step Certificates by running: ansible-playbook -i inventory nas.yml -b -K -t stepca 
+# Once you have initialized the CA, set to "false".
+stepca_init: false
 
 ###
 ### Heimdall

--- a/nas.yml
+++ b/nas.yml
@@ -199,3 +199,7 @@
   - import_tasks: tasks/cloudcmd.yml
     when: (cloudcmd_enabled | default(False))
     tags: cloudcmd
+
+  - import_tasks: tasks/step-ca.yml
+    when: (stepca_enabled | default(False))
+    tags: stepca

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -32,7 +32,7 @@
       step ca init
       --name 'Ansible-NAS CA'
       --provisioner {{ ansible_nas_email }}
-      --dns {{ ansible_nas_domain }}
+      --dns stepca.{{ ansible_nas_domain }}
       --address ':8443'
       --password-file secrets/intermediate_pass
   when: (stepca_init | default(False))

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -28,7 +28,13 @@
     volumes:
       - "{{ stepca_directory }}:/home/step:rw"
     memory: 1g
-    command: "step ca init --name 'Ansible-NAS CA' --provisioner {{ ansible_nas_email }} --dns {{ ansible_nas_domain }} --address ':8443' --password-file secrets/intermediate_pass"
+    command: |
+      step ca init
+      --name 'Ansible-NAS CA'
+      --provisioner {{ ansible_nas_email }}
+      --dns {{ ansible_nas_domain }}
+      --address ':8443'
+      --password-file secrets/intermediate_pass
   when: (stepca_init | default(False))
 
 - name: Create ACME provisioner

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -40,11 +40,7 @@
       --dns stepca.{{ ansible_nas_domain }}
       --address ':8443'
       --password-file secrets/intermediate_pass
-  when: stepca_json.stat.exists == False
-
-- name: Get Step Certificates ca.json
-  command: cat "{{ stepca_directory }}/config/ca.json"
-  register: stepca_json_content
+  when: not stepca_json.stat.exists
 
 - name: Create ACME provisioner
   docker_container:
@@ -56,7 +52,7 @@
       - "{{ stepca_directory }}:/home/step:rw"
     memory: 1g
     command: "step ca provisioner add acme --type ACME"
-  when: stepca_json_content.stdout.find('ACME') == -1
+  when: lookup('file', stepca_directory + "/config/ca.json").find('ACME') == -1
 
 - name: Create Step Certificates container
   docker_container:

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -1,0 +1,46 @@
+---
+- name: Create step-ca directory
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: 1000
+    group: 1000
+  with_items:
+    - "{{ stepca_directory }}"
+    - "{{ stepca_directory }}/config"
+    - "{{ stepca_directory }}/certs"
+    - "{{ stepca_directory }}/db"
+    - "{{ stepca_directory }}/secrets"
+
+- name: Create step-ca password file
+  copy:
+    content: "{{ stepca_password }}"
+    dest: "{{ stepca_directory }}/secrets/intermediate_pass"
+    owner: 1000
+    group: 1000
+
+- name: Initialize Step Certificates CA
+  docker_container:
+    name: step-ca
+    image: smallstep/step-ca
+    pull: true
+    cleanup: yes
+    volumes:
+      - "{{ stepca_directory }}:/home/step:rw"
+    memory: 1g
+    command: "step ca init --name 'Ansible-NAS CA' --provisioner {{ ansible_nas_email }} --dns stepca.{{ ansible_nas_domain }} --address ':8443' --password-file secrets/intermediate_pass"
+  when: (stepca_init | default(False)) 
+
+- name: Create Step Certificates container 
+  docker_container:
+    name: step-ca
+    image: smallstep/step-ca
+    pull: true
+    volumes:
+      - "{{ stepca_directory }}:/home/step:rw"
+    ports:
+      - "8443:8443"
+    restart_policy: unless-stopped
+    memory: 1g
+    env:
+      PWDPATH: /home/step/secrets/intermediate_pass

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -29,7 +29,7 @@
       - "{{ stepca_directory }}:/home/step:rw"
     memory: 1g
     command: "step ca init --name 'Ansible-NAS CA' --provisioner {{ ansible_nas_email }} --dns {{ ansible_nas_domain }} --address ':8443' --password-file secrets/intermediate_pass"
-  when: (stepca_init | default(False)) 
+  when: (stepca_init | default(False))
 
 - name: Create ACME provisioner
   docker_container:
@@ -41,9 +41,9 @@
       - "{{ stepca_directory }}:/home/step:rw"
     memory: 1g
     command: "step ca provisioner add acme --type ACME"
-  when: (stepca_init | default(False)) 
+  when: (stepca_init | default(False))
 
-- name: Create Step Certificates container 
+- name: Create Step Certificates container
   docker_container:
     name: step-ca
     image: smallstep/step-ca

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -39,6 +39,7 @@
       --provisioner {{ ansible_nas_email }}
       --dns stepca.{{ ansible_nas_domain }}
       --address ':8443'
+      --ssh
       --password-file secrets/intermediate_pass
   when: not stepca_json.stat.exists
 

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -28,7 +28,19 @@
     volumes:
       - "{{ stepca_directory }}:/home/step:rw"
     memory: 1g
-    command: "step ca init --name 'Ansible-NAS CA' --provisioner {{ ansible_nas_email }} --dns stepca.{{ ansible_nas_domain }} --address ':8443' --password-file secrets/intermediate_pass"
+    command: "step ca init --name 'Ansible-NAS CA' --provisioner {{ ansible_nas_email }} --dns {{ ansible_nas_domain }} --address ':8443' --password-file secrets/intermediate_pass"
+  when: (stepca_init | default(False)) 
+
+- name: Create ACME provisioner
+  docker_container:
+    name: step-ca
+    image: smallstep/step-ca
+    pull: true
+    cleanup: yes
+    volumes:
+      - "{{ stepca_directory }}:/home/step:rw"
+    memory: 1g
+    command: "step ca provisioner add acme --type ACME"
   when: (stepca_init | default(False)) 
 
 - name: Create Step Certificates container 
@@ -43,4 +55,4 @@
     restart_policy: unless-stopped
     memory: 1g
     env:
-      PWDPATH: /home/step/secrets/intermediate_pass
+      PWDPATH: "/home/step/secrets/intermediate_pass"

--- a/tasks/step-ca.yml
+++ b/tasks/step-ca.yml
@@ -19,6 +19,11 @@
     owner: 1000
     group: 1000
 
+- name: Check whether Step Certificates ca.json exists
+  stat:
+    path: "{{ stepca_directory }}/config/ca.json"
+  register: stepca_json
+
 - name: Initialize Step Certificates CA
   docker_container:
     name: step-ca
@@ -35,7 +40,11 @@
       --dns stepca.{{ ansible_nas_domain }}
       --address ':8443'
       --password-file secrets/intermediate_pass
-  when: (stepca_init | default(False))
+  when: stepca_json.stat.exists == False
+
+- name: Get Step Certificates ca.json
+  command: cat "{{ stepca_directory }}/config/ca.json"
+  register: stepca_json_content
 
 - name: Create ACME provisioner
   docker_container:
@@ -47,7 +56,7 @@
       - "{{ stepca_directory }}:/home/step:rw"
     memory: 1g
     command: "step ca provisioner add acme --type ACME"
-  when: (stepca_init | default(False))
+  when: stepca_json_content.stdout.find('ACME') == -1
 
 - name: Create Step Certificates container
   docker_container:

--- a/tasks/traefik.yml
+++ b/tasks/traefik.yml
@@ -15,6 +15,13 @@
     state: directory
   with_items:
     - "{{ traefik_data_directory }}"
+    - "{{ traefik_data_directory }}/acme"
+
+- name: Create acme.json with right permissions
+  file:
+    path: "{{ traefik_data_directory }}/acme/acme.json"
+    state: touch
+    mode: u=rw,g-rwx,o-rwx
 
 - name: Template Traefik config.toml
   template:
@@ -29,6 +36,7 @@
     network_mode: host
     volumes:
       - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
+      - "{{ traefik_data_directory }}/acme:/etc/traefik/acme"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "{{ stepca_directory }}/certs:/certs:ro"
     restart_policy: unless-stopped

--- a/tasks/traefik.yml
+++ b/tasks/traefik.yml
@@ -30,5 +30,8 @@
     volumes:
       - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "{{ stepca_directory }}/certs:/certs:ro"
     restart_policy: unless-stopped
     memory: 1g
+    env:
+      LEGO_CA_CERTIFICATES: "/certs/root_ca.crt"

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -208,6 +208,7 @@ onDemand = false # create certificate when container is created
           "radarr.{{ ansible_nas_domain }}",
           "sickchill.{{ ansible_nas_domain }}",
           "sonarr.{{ ansible_nas_domain }}",
+          "stepca.{{ ansible_nas_domain }}",
           "tautulli.{{ ansible_nas_domain }}",
           "thelounge.{{ ansible_nas_domain }}",
           "transmission.{{ ansible_nas_domain }}",

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -164,15 +164,21 @@ storage = "acme.json"
 entryPoint = "https"
 acmeLogging = true
 onDemand = false # create certificate when container is created
+{% if stepca_enabled | default(False) %}
+caServer = "https://{{ ansible_nas_domain }}:8443/acme/acme/directory"
+{% endif %}
 
   # [acme.dnsChallenge]
   # provider = "cloudflare"
   # delayBeforeCheck = 0
 
-  # [acme.httpChallenge]
-  # entryPoint = "http"
-
+{% if stepca_enabled | default(False) %}
+  [acme.httpChallenge]
+  entryPoint = "http"
+{% else %}
   [acme.tlsChallenge]
+{% endif %}
+
 
   [[acme.domains]]
   main = "ansible-nas.{{ ansible_nas_domain }}"

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -160,7 +160,7 @@ exposedByDefault = false
 
 [acme]
 email = "{{ ansible_nas_email }}"
-storage = "acme.json"
+storage = "/etc/traefik/acme/acme.json"
 entryPoint = "https"
 acmeLogging = true
 onDemand = false # create certificate when container is created

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -165,7 +165,7 @@ entryPoint = "https"
 acmeLogging = true
 onDemand = false # create certificate when container is created
 {% if stepca_enabled | default(False) %}
-caServer = "https://{{ ansible_nas_domain }}:8443/acme/acme/directory"
+caServer = "https://stepca.{{ ansible_nas_domain }}:8443/acme/acme/directory"
 {% endif %}
 
   # [acme.dnsChallenge]


### PR DESCRIPTION
Step Certificates is a private certificate authority (CA) and ACME server. With this pull request, Traefik can use it instead of Let's Encrypt (and other services on your network can use it too), so you are in full control of your certificate infrastructure.

This is a more robust and flexible approach than using a self-signed certificate such as in https://github.com/davestephens/ansible-nas/issues/128. I have been successfully running this branch here for a few weeks now on my Ansible-NAS box.

I don't use Let's Encrypt, so this needs some review, especially for the changes I made in `templates/traefik/traefik.toml` and `tasks/traefik.yml`. For instance, probably the latter task will fail now when you don't use Step Certificates because it refers to directories in the Step Certificates container directory. I don't know how to make this conditional.