### PR TITLE
Quote the Vagrant test script here document's delimiting identifier

### DIFF
--- a/tests/test-vagrant.sh
+++ b/tests/test-vagrant.sh
@@ -4,7 +4,7 @@ PLAYBOOK_DIR=$DIR/..
 
 header() {
     clear
-    cat << EndOfMessage
+    cat << "EndOfMessage"
                      ._____.   .__
 _____    ____   _____|__\_ |__ |  |   ____             ____ _____    ______
 \__  \  /    \ /  ___/  || __ \|  | _/ __ \   ______  /    \\__  \  /  ___/


### PR DESCRIPTION
Quoting prevents interpretation of things like backslash characters.