### PR TITLE
homeassistant: use host networking

### DIFF
--- a/tasks/homeassistant.yml
+++ b/tasks/homeassistant.yml
@@ -12,8 +12,7 @@
     pull: true
     volumes:
       - "{{ homeassistant_data_directory }}/config:/config:rw"
-    ports:
-      - "8123:8123"
+    network_mode: host
     restart_policy: unless-stopped
     env:
       TZ: "{{ ansible_nas_timezone }}"


### PR DESCRIPTION
Homeassistant discovery requires that the docker container be
configured for host networking.

See: https://www.home-assistant.io/docs/installation/docker/

Fixes: #217