### PR TITLE
Installation pymodule update

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,6 +11,12 @@ You can run Ansible-NAS from the computer you plan to use for your NAS, or from 
 
 2. Install Ansible:
 
+    `sudo apt update`
+
+    `sudo apt install software-properties-common`
+
+    `sudo apt-add-repository --yes --update ppa:ansible/ansible`
+
     `sudo apt install ansible`
 
 3. Clone Ansible-NAS:

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -5,7 +5,7 @@
     state: present
   register: result
   until: result is succeeded
-  
+
 - name: 'Check if docker-py is installed'
   shell: pip3 show docker-py
   failed_when: docker_py_check.rc != 1 and docker_py_check.rc != 0

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -5,7 +5,7 @@
     state: present
   register: result
   until: result is succeeded
-
+  
 - name: 'Check if docker-py is installed'
   shell: pip3 show docker-py
   failed_when: docker_py_check.rc != 1 and docker_py_check.rc != 0

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -8,7 +8,7 @@
   
 - name: 'Check if docker-py is installed'
   shell: pip3 show docker-py
-  ignore_errors: true
+  failed_when: docker_py_check.rc != 1 and docker_py_check.rc != 0
   register: docker_py_check
 
 - name: 'Remove docker-py if installed'

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -8,7 +8,7 @@
   
 - name: 'Check if docker-py is installed'
   shell: pip3 show docker-py
-  failed_when: docker_py_check.rc != 1 and docker_py_check.rc != 0
+  ignore_errors: true
   register: docker_py_check
 
 - name: 'Remove docker-py if installed'

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -5,19 +5,6 @@
     state: present
   register: result
   until: result is succeeded
-  
-- name: 'Check if docker-py is installed'
-  shell: pip3 show docker-py
-  ignore_errors: true
-  register: docker_py_check
-
-- name: 'Remove docker-py if installed'
-  pip:
-    name: docker-py
-    state: absent
-  when: docker_py_check.stdout.find('docker-py') != -1
-  register: result
-  until: result is succeeded
 
 - name: 'Install docker python module'
   pip:

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -6,6 +6,13 @@
   register: result
   until: result is succeeded
 
+- name: 'Remove docker-py python module'
+  pip:
+    name: docker-py
+    state: absent
+  register: result
+  until: result is succeeded
+
 - name: 'Install docker python module'
   pip:
     name: docker

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -5,6 +5,19 @@
     state: present
   register: result
   until: result is succeeded
+  
+- name: 'Check if docker-py is installed'
+  shell: pip3 show docker-py
+  ignore_errors: true
+  register: docker_py_check
+
+- name: 'Remove docker-py if installed'
+  pip:
+    name: docker-py
+    state: absent
+  when: docker_py_check.stdout.find('docker-py') != -1
+  register: result
+  until: result is succeeded
 
 - name: 'Install docker python module'
   pip:

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -6,9 +6,9 @@
   register: result
   until: result is succeeded
 
-- name: 'Install docker-py'
+- name: 'Install docker python module'
   pip:
-    name: docker-py
+    name: docker
     state: present
   register: result
   until: result is succeeded


### PR DESCRIPTION
**What this PR does / why we need it**:
Existing Ansible installation instructions will result in version 2.5.2 rather than the current 2.9.x version.
Official Ansible documentation has been updated as per the change in docs/installation.md.

Additionally the docker-py module is deprecated and has been replaced with the 'docker' module.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
These two changes are needed for the upcoming Traefik 2.1.1 PR I will be submitting once finished testing.