### PR TITLE
Add DB_CONNECTION: "mysql" to the tasks/firefly.yml file because this as

### DIFF
--- a/tasks/firefly.yml
+++ b/tasks/firefly.yml
@@ -42,6 +42,7 @@
     env:
       APP_ENV: "local"
       APP_KEY: "S0m3R@nd0mString0f32Ch@rsEx@ct1y"
+      DB_CONNECTION: "mysql"
       DB_HOST: "db"
       DB_DATABASE: "firefly"
       DB_USERNAME: "firefly"


### PR DESCRIPTION
the default setting was removed from the upstream firefly code.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->
I've tried and tried to get it tested with test-vagrant.sh. I can't seem to get it to accept any connections to view it. However, this is a super simple change that takes my actual working server from having a broken installation of firefly to actually working just fine. After looking through just what is being attempted with the test script and seeing the difference in my server, I think that this is good enough. If not, I'm going to need some hand-holding in getting a working test setup. I've put far more time in trying to figure that out than in solving the actual problem. (Of course, that's only because this was such a simple fix.)

**What this PR does / why we need it**:
Adds in an environment variable in tasks/firefly.yml to set the database to be mysql.


**Which issue (if any) this PR fixes**:
As of ~2/2/20, the upstream code was changed to no longer default to have the database be mysql. Without setting the variable, the code just fails and the website will not load.

Fixes #

**Any other useful info**:
