### PR TITLE
Account for new Sanoid dependency in docs.

### DIFF
--- a/docs/zfs/zfs_configuration.md
+++ b/docs/zfs/zfs_configuration.md
@@ -293,7 +293,7 @@ First, we install sanoid to the `/opt` directory. This assumes that Perl itself
 is already installed.
 
 ```
-        sudo apt install libconfig-inifiles-perl
+        sudo apt install libconfig-inifiles-perl libcapture-tiny-perl
         cd /opt
         sudo git clone https://github.com/jimsalterjrs/sanoid
 ```


### PR DESCRIPTION
Sanoid now requires an additional perl package that wasn't installed by default on Ubuntu 18.04 server.

-Dale