### PR TITLE
Add Hddtemp monitoring to Telegraf/InfluxDB/Grafana.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Ansible config and a bunch of Docker containers.
 * [Glances](https://nicolargo.github.io/glances/) - for seeing the state of your system via a web browser
 * [Grafana](https://github.com/grafana/grafana) - Dashboarding tool
 * [Guacamole](https://guacamole.apache.org/) - Web based remote desktop gateway, supports VNC, RDP and SSH
+* [Hddtemp](https://savannah.nongnu.org/projects/hddtemp/) - Small utility that provides hard drive temperature data
 * [Heimdall](https://heimdall.site/) - Home server dashboard
 * [Home Assistant](https://www.home-assistant.io) - Open source home automation
 * [InfluxDB](https://github.com/influxdata/influxdb) - Time series database used for stats collection

--- a/tasks/stats.yml
+++ b/tasks/stats.yml
@@ -34,10 +34,29 @@
       INFLUXDB_LOGGING_LEVEL: "error"
     memory: 1g
 
+- name: Hddtemp
+  docker_container:
+    name: hddtemp
+    image: drewster727/hddtemp-docker
+    pull: true
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "/dev:/dev:ro"
+    env:
+      HDDTEMP_ARGS: "-q -d -F /dev/sd*"
+      TZ: "{{ ansible_nas_timezone }}"
+    privileged: true
+    restart_policy: unless-stopped
+    memory: 1g
+  register:
+    hddtemp_data
+
 - name: Template telegraf.conf
   template:
     src: telegraf/telegraf.conf
     dest: "{{ telegraf_data_directory }}/telegraf.conf"
+  vars:
+    hddtemp_ip: "{{ hddtemp_data.ansible_facts.docker_container.NetworkSettings.IPAddress }}"
 
 - name: Telegraf
   docker_container:

--- a/templates/telegraf/telegraf.conf
+++ b/templates/telegraf/telegraf.conf
@@ -272,7 +272,7 @@
 
 
 # # Monitor disks' temperatures using hddtemp
-# [[inputs.hddtemp]]
+[[inputs.hddtemp]]
 #   ## By default, telegraf gathers temps data from all disks detected by the
 #   ## hddtemp.
 #   ##
@@ -280,7 +280,7 @@
 #   ##
 #   ## A * as the device name will return the temperature values of all disks.
 #   ##
-#   # address = "127.0.0.1:7634"
+  address = "{{ hddtemp_ip }}:7634"
 #   # devices = ["sda", "*"]
 
 # Read metrics about network interface usage


### PR DESCRIPTION
**What this PR does / why we need it**:

Add temperature monitoring to InfluxDB through Telegraf, for use in Grafana.

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:
