### PR TITLE
Added config variable to override nextcloud users data directory

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -590,6 +590,7 @@ glances_port_two: "61209"
 ###
 nextcloud_available_externally: "false"
 nextcloud_data_directory: "{{ docker_home }}/nextcloud"
+nextcloud_users_files_directory: "{{ docker_home }}/nextcloud/nextcloud/data"
 nextcloud_port: "8080"
 
 ###

--- a/tasks/nextcloud.yml
+++ b/tasks/nextcloud.yml
@@ -6,6 +6,7 @@
   with_items:
     - "{{ nextcloud_data_directory }}/nextcloud"
     - "{{ nextcloud_data_directory }}/mysql"
+    - "{{ nextcloud_users_files_directory }}"
 
 - name: Nextcloud Mysql Docker Container
   docker_container:
@@ -31,6 +32,7 @@
         - nextcloud-mysql:mysql
     volumes:
       - "{{ nextcloud_data_directory }}/nextcloud:/var/www/html:rw"
+      - "{{ nextcloud_users_files_directory }}:/var/www/html/data:rw"
     ports:
       - "{{ nextcloud_port }}:80"
     env:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the ability to specify a custom users data directory path for Nextcloud.
According to [docs](https://hub.docker.com/_/nextcloud/) we can mount volume to default data path "/var/www/html/data", which is used to store users data.

*My personal use case:*

I have 2 SSD (one used for OS, boot, and swap, the second one - for home directory) and several HDD.
All my docker containers, configs, etc, use the second SSD, but I want to store user's files on my HDD. In my opinion data storage should be split from the application (nextcloud) filesystem. That is the aim of this PR.
