### PR TITLE
Use hostname defined in all.yml for main hostname in traefik template

### DIFF
--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -175,7 +175,7 @@ onDemand = false # create certificate when container is created
   [acme.tlsChallenge]
 
   [[acme.domains]]
-  main = "ansible-nas.{{ ansible_nas_domain }}"
+  main = "{{ ansible_nas_hostname }}.{{ ansible_nas_domain }}"
 
 
   # we request a certificate for everything, because why not.


### PR DESCRIPTION
**What this PR does / why we need it**:

Change to use the variable defined hostname instead of hardcoded "ansible-nas" 

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:
None, simple and concise.