### PR TITLE
Update role requirements to latest versions

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,9 +1,9 @@
 ---
 - name: geerlingguy.docker
-  version: 2.5.2
+  version: 2.7.0
 
 - name: bertvv.samba
-  version: v2.7.0
+  version: v2.7.1
 
 - name: geerlingguy.nfs
   version: 1.5.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Update role requirements to latest versions

I've been running the latest geerlingguy.docker 2.7.0 now for about a month with no problems.
bertvv.samba 2.7.0 updated to 2.7.1 which is the latest. Just switched to it today, 

Old versions might be a minimum requirement, but using the latest takes advantage of any fixes and new features.

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

Also removes the existing trailing space for the geerlingguy.nfs version. :)
