### PR TITLE
Update Plex default memory limitation 1g -> 2g

### DIFF
--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -25,7 +25,7 @@
       PUID: "{{ plex_user_id }}"
       PGID: "{{ plex_group_id }}"
     restart_policy: unless-stopped
-    memory: 1g
+    memory: 2g
     labels:
       traefik.backend: "plex"
       traefik.frontend.rule: "Host:plex.{{ ansible_nas_domain }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the default memory limitation for the Plex container from 1Gb to 2Gb. (Though I prefer more, but that's addressed as a feature request in https://github.com/davestephens/ansible-nas/issues/253 .) Realigns with Plex's recommendation (see reference below). Basically more "breathing room" for transcoding.

REF: https://www.reddit.com/r/PleX/comments/61zb8m/plex_media_server_and_ram_usage/

REF: https://support.plex.tv/articles/200375666-plex-media-server-requirements/
> RAM
> In general, Plex Media Server doesn’t require large amounts of RAM. 2GB of RAM is typically more than sufficient and some installs (particularly Linux-based installs) can often happily run with even less. Of course, more RAM won’t hurt you and will certainly be helpful if you’re also doing other things on the computer.
> 

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:
