### PR TITLE
Change samba_shares_root and nfs_shares_root default to more common default

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -147,7 +147,7 @@ docker_storage_driver: overlay2
 ###
 # The location where all shares will be created by default. Can be overridden on a per-share basis.
 # This path will be mounted to backup containers, Duplicati
-samba_shares_root: /mnt/Volume3
+samba_shares_root: /mnt/md0
 
 # Where stuff downloaded will be stored
 downloads_root: "{{ samba_shares_root }}/downloads"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -268,7 +268,7 @@ samba_shares:
 # https://help.ubuntu.com/community/SettingUpNFSHowTo#Shares
 # WARNING: Weird things might happen if you share the same data over Samba and NFS and allow writes on both!
 
-nfs_shares_root: /mnt/Volume3
+nfs_shares_root: /mnt/md0
 
 nfs_exports:
   - "{{ nfs_shares_root }}/public *(rw,sync,no_root_squash)"


### PR DESCRIPTION
**What this PR does / why we need it**:

DISCRETIONARY

Change samba_shares_root: to more common occurrence; md0 instead of Volume3.

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

It's in this user's opinion that "Volume3" is a more personal reference to Ansible-NAS's author's setup and the default Samba share example might be better served using the default first mdadm RAID mount point of /mnt/md0. Of course there's the growing popularity of ZFS as well, but I don't use that. :)

This PR can be changed or shot down without prejudice. 