### PR TITLE
application_ports.md - add missing information

### DIFF
--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -1,62 +1,72 @@
 # Application Ports
 
 By default, applications can be found on the ports listed below.
+* = the application is in host, not bridged mode.
 
 | Application     | Port   | Notes        |
 |-----------------|--------|--------------|
-| Airsonic        | 4040   |              |
-| Bazarr          | 6767   |              |
-| Bitwarden "hub" | 3012   | Web Not.     |
-| Bitwarden       | 19080  | HTTP         |
+| Airsonic        | 4040   | HTTP         |
+| Bazarr          | 6767   | HTTP         |
+| Bitwarden "hub" | 3012   | Web Not. *   |
+| Bitwarden       | 19080  | HTTP *       |
 | Calibre         | 8084   | HTTP         |
-| Cloud Commander | 7373   |              |
-| Couchpotato     | 5050   |              |
-| Duplicati       | 8200   |              |
+| Cloud Commander | 7373   | HTTP         |
+| Couchpotato     | 5050   | HTTP         |
+| Duplicati       | 8200   | HTTP         |
 | Emby            | 8096   | HTTP         |
 | Emby            | 8920   | HTTPS        |
-| Firefly III     | 8066   |              |
-| get_iplayer     | 8182   |              |
-| Gitea           | 3001   | Web          |
+| Firefly III     | 8066   | HTTP         |
+| get_iplayer     | 8182   | HTTP         |
+| Gitea           | 3001   | HTTP         |
 | Gitea           | 222    | SSH          |
 | Gitlab          | 4080   | HTTP         |
 | Gitlab          | 4443   | HTTPS        |
 | Gitlab          | 422    | SSH          |
-| Glances         | 61208  | SSH          |
-| Grafana         | 3000   |              |
-| Guacamole       | 8090   |              |
-| Heimdall        | 10080  |              |
-| Home Assistant  | 8123   |              |
-| Homebridge      | 8087   |              |
-| Jackett         | 9117   |              |
+| Glances         | 61208  | HTTP *       |
+| Grafana         | 3000   | HTTP         |
+| Guacamole       | 8090   | HTTP         |
+| Heimdall        | 10080  | HTTP         |
+| Heimdall        | 10443  | HTTPS        |
+| Home Assistant  | 8123   | HTTP *       |
+| Homebridge      | 8087   | HTTP *       |
+| InfluxDB        | 8086   | HTTP *       |
+| Jackett         | 9117   | HTTP         |
 | Jellyfin        | 8896   | HTTP         |
 | Jellyfin        | 8928   | HTTPS        |
-| Lidarr          | 8686   |              |
-| MiniDLNA        | 8201   |              |
-| Miniflux        | 8070   |              |
+| Lidarr          | 8686   | HTTP         |
+| MiniDLNA        | 8201   | HTTP *       |
+| Miniflux        | 8070   | HTTP         |
 | Mosquitto       | 1883   | MQTT         |
 | Mosquitto       | 9001   | Websocket    |
-| MyMediaForAlexa | 52051  |              |
-| Netdata         | 19999  |              |
-| Nextcloud       | 8080   |              |
-| NZBGet          | 6789   |              |
-| Ombi            | 3579   |              |
-| openHAB         | 7777   | HTTP         |
-| openHAB         | 7778   | HTTPS        |
-| Plex            | 32400  |              |
-| Portainer       | 9000   |              |
-| pyload          | 8000   |              |
-| Radarr          | 7878   |              |
+| MyMediaForAlexa | 52050  | (stream) *   |
+| MyMediaForAlexa | 52051  | HTTP *       |
+| Netdata         | 19999  | HTTP         |
+| Nextcloud       | 8080   | HTTP         |
+| NZBGet          | 6789   | HTTP         |
+| Ombi            | 3579   | HTTP         |
+| openHAB         | 7777   | HTTP *       |
+| openHAB         | 7778   | HTTPS *      |
+| Plex            | 32400  | HTTP *       |
+| Portainer       | 9000   | HTTP         |
+| pyload          | 8000   | HTTP         |
+| Radarr          | 7878   | HTTP         |
 | Serposcope      | 7134   |              |
-| Sickchill       | 8081   |              |
-| Sonarr          | 8989   |              |
-| Tautulli        | 8185   |              |
-| The Lounge      | 9000   |              |
+| Sickchill       | 8081   | HTTP         |
+| Sonarr          | 8989   | HTTP         |
+| Tautulli        | 8185   | HTTP *       |
+| The Lounge      | 113    | IRC          |
+| The Lounge      | 9000   | HTTP         |
 | Time Machine    | 10445  | SMB          |
-| Traefik         | 8083   |              |
-| Transmission    | 9091   | with VPN     |
-| Transmission    | 3128   | http proxy   |
-| Transmission    | 9092   |              |
-| Ubooquity       | 2202   |              |
-| Ubooquity       | 2203   | Admin        |
-| Wallabag        | 7780   |              |
-| ZNC             | 6677   |              |
+| Traefik         | 80     | HTTP *       |
+| Traefik         | 443    | HTTPS        |
+| Traefik         | 8083   | HTTP inter * |
+| Transmission    | 3128   | HTTP proxy   |
+| Transmission    | 9091   | HTTP w/VPN   |
+| Transmission    | 9092   | HTTP inter   |
+| Transmission    | 51414  | BT           |
+| Transmission    | 51415  | BT w/VPN     |
+| Ubooquity       | 2202   | HTTP inter   |
+| Ubooquity       | 2203   | HTTP Admin   |
+| Wallabag        | 7780   | HTTP         |
+| Wallabag        | 7781   | HTTPS        |
+| ZNC             | 6677   | IRC          |


### PR DESCRIPTION
**What this PR does / why we need it**:

- Added a few undocumented ports; e.g. Heimdall and Transmission
- Documented ports that are in host mode
- Filled in the missing protocols where I could; not sure about Serposcope (Dave!), and please double check ZNC if I understood it correctly (I don't use it.)

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

I'd like to redo the list later and add more columns; move the *'d host mode info to a column stating H for host mode or B for bridge mode, or simply make the rename Notes column to a protocol column and then re-add a wider Notes column. 

I think it's important to get this updated soon to make it current for anyone else configuring new apps (ports!) to add to ansible-nas.

Oh yeah...
Rage against the NAS!