### PR TITLE
DOCS: add missing Tautulli documentation

### DIFF
--- a/docs/applications/tautulli.md
+++ b/docs/applications/tautulli.md
@@ -1,0 +1,12 @@
+
+# Tautulli
+
+Homepage: [https://tautulli.com/](https://tautulli.com/)
+
+Tautulli allows you to monitor your Plex Media Server.
+
+## Usage
+
+Set `tautulli_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The Tautulli web interface can be found at http://ansible_nas_host_or_ip:8181.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds missing Tautulli documentation file.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
