### PR TITLE
DOCS: fixed capitalization errors - "wallabag" is official spelling

### DIFF
--- a/docs/applications/wallabag.md
+++ b/docs/applications/wallabag.md
@@ -1,4 +1,4 @@
-# Wallabag
+# wallabag
 
 Homepage: [https://www.wallabag.org/](https://www.wallabag.org/)
 
@@ -8,10 +8,10 @@ wallabag is a self-hostable PHP application allowing you to not miss any content
 
 Set `wallabag_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
 
-If you want to access Wallabag externally, don't forget to set `wallabag_available_externally: "true"` in your `inventories/<your_inventory>/nas.yml` file.
+If you want to access wallabag externally, don't forget to set `wallabag_available_externally: "true"` in your `inventories/<your_inventory>/nas.yml` file.
 
 I reccomend using the mobile app, which will sync with this installation so you have access to your saved articles even if you don't have signal or wifi access.
 
 The default credentials are wallabag:wallabag
 
-The Wallabag web interface can be found at http://ansible_nas_host_or_ip:7780.
+The wallabag web interface can be found at http://ansible_nas_host_or_ip:7780.


### PR DESCRIPTION
**What this PR does / why we need it**:

fixed capitalization errors - "wallabag" is official spelling

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:
