### PR TITLE
Calibre -> Calibre-web - consistent and proper global naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - Provides a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
+* [Calibre-web](https://github.com/janeczku/calibre-web) - Provides a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Ansible config and a bunch of Docker containers.
 * A Docker host with Portainer for image and container management
 * An automatic dynamic DNS updater if you use Cloudflare to host your domain DNS
 * A Personal finance manager
-* eBook management with calibre-web
+* eBook management with Calibre-web
 * Content management with Joomla
 * A dual panel local file manager
 * Self-service media request web application

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - Provides a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/docs/applications/calibre.md
+++ b/docs/applications/calibre.md
@@ -1,6 +1,6 @@
 # Calibre-web
 
-Homepage: [https://github.com/linuxserver/docker-calibre-web](https://github.com/linuxserver/docker-calibre-web)
+Homepage: [https://github.com/janeczku/calibre-web](https://github.com/janeczku/calibre-web)
 
 
 Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.

--- a/docs/applications/calibre.md
+++ b/docs/applications/calibre.md
@@ -1,6 +1,6 @@
 # Calibre-web
 
-Homepage: [https://github.com/janeczku/calibre-web](https://github.com/linuxserver/docker-calibre-web)
+Homepage: [https://github.com/linuxserver/docker-calibre-web](https://github.com/linuxserver/docker-calibre-web)
 
 
 Calibre-Web is a web app providing a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.

--- a/docs/applications/calibre.md
+++ b/docs/applications/calibre.md
@@ -1,4 +1,4 @@
-# Calibre(-web) eBook Library
+# Calibre-web
 
 Homepage: [https://github.com/janeczku/calibre-web](https://github.com/linuxserver/docker-calibre-web)
 

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -8,7 +8,7 @@ By default, applications can be found on the ports listed below.
 | Bazarr          | 6767   |              |
 | Bitwarden "hub" | 3012   | Web Not.     |
 | Bitwarden       | 19080  | HTTP         |
-| Calibre         | 8084   | HTTP         |
+| Calibre-web     | 8084   | HTTP         |
 | Cloud Commander | 7373   |              |
 | Couchpotato     | 5050   |              |
 | Duplicati       | 8200   |              |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -755,7 +755,7 @@ mosquitto_port_a: "1883"
 mosquitto_port_b: "9001"
 
 ###
-### Calibre
+### Calibre-web
 ###
 calibre_available_externally: "false"
 calibre_data_directory: "{{ docker_home }}/calibre"

--- a/tasks/calibre.yml
+++ b/tasks/calibre.yml
@@ -1,11 +1,11 @@
-- name: Create Calibre Directories
+- name: Create Calibre-web Directories
   file:
     path: "{{ item }}"
     state: directory
   with_items:
     - "{{ calibre_data_directory }}/config"
 
-- name: Calibre Docker Container
+- name: Calibre-web Docker Container
   docker_container:
     name: calibre
     image: linuxserver/calibre-web:latest


### PR DESCRIPTION
**What this PR does / why we need it**:

Calibre -> Calibre-web name corrections

**Which issue (if any) this PR fixes**:

Fixes # n/a 

**Any other useful info**:
Ansible-NAS does not include Calibre, it incorrectly references Calibre-web as Calibre.
Though it will be a breaking change to add Calibre, this is step one in actually adding Calibre to Ansible-NAS.