### PR TITLE
WIP: Glances - make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -586,6 +586,9 @@ gitlab_port_ssh: "422"
 ### Glances
 ###
 glances_available_externally: "false"
+glances_data_directory: "{{ docker_home }}/glances"
+glances_options: "-w"
+glances_memory_limit: "512m"
 glances_port_one: "61208"
 glances_port_two: "61209"
 

--- a/tasks/glances.yml
+++ b/tasks/glances.yml
@@ -1,3 +1,33 @@
+- name: Create Glances Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ glances_data_directory }}/conf"
+    - templates/glances/conf"
+
+- name: Glances download glances.config
+  get_url:
+    url: https://raw.githubusercontent.com/nicolargo/glances/develop/conf/glances.conf
+    dest: templates/glances/glances.conf
+
+- name: Glances download glances-grafana.json
+  get_url:
+    url: https://raw.githubusercontent.com/nicolargo/glances/develop/conf/glances-grafana.json
+    dest: templates/glances/glances-grafana.json
+
+- name: Glances copy glances.conf
+  copy:
+    src: templates/glances/glances.conf
+    dest: "{{ glances_data_directory }}/conf/glances.conf"
+    backup: yes
+
+- name: Glances copy glances-grafana.json
+  copy:
+    src: templates/glances/glances-grafana.json
+    dest: "{{ glances_data_directory }}/conf/glances-grafana.json"
+    backup: yes
+
 - name: Glances Docker Container
   docker_container:
     name: glances
@@ -7,15 +37,15 @@
       - "{{ glances_port_one }}:61208"
       - "{{ glances_port_two }}:61209"
     volumes:
-      #- "/glances.conf:/glances/conf/glances.conf"
+      - "{{ glances_data_directory }}/conf:/glances/conf:rw"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "/etc/timezone:/etc/timezone:ro"
     pid_mode: host
     network_mode: host
     env:
-      GLANCES_OPT: "-w"
+      GLANCES_OPT: "{{ glances_options }}"
     restart_policy: unless-stopped
-    memory: 1g
+    memory: "{{ glances_memory_limit }}"
     labels:
       traefik.backend: "glances"
       traefik.frontend.rule: "Host:glances.{{ ansible_nas_domain }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

* Makes Glances configurable via native glances.conf which downloads from the dev's GH repo instead of it having to be part of the ansible-nas repo
* Makes Glances memory limit configurable, also subjectively changes default to 512m as I've never seen Glances go over ~100m (really want to set it to 256m, but it's well behaved....)
* Makes Glances environmental options variable instead of static "-w"

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:
