### PR TITLE
ADDITION: Unifi (controller)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Ansible config and a bunch of Docker containers.
 * [Traefik](https://traefik.io/) - Web proxy and SSL certificate manager
 * [Transmission](https://transmissionbt.com/) - BitTorrent client (with OpenVPN if you have a supported VPN provider)
 * [Ubooquity](http://vaemendis.net/ubooquity/) - Book and comic server
+* [Unifi Controller](https://unifi-network.ui.com/) - The UniFi® Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations — all controlled from a single interface.
 * [Virtual Desktop](https://github.com/RattyDAVE/docker-ubuntu-xrdp-mate-custom) - A virtual desktop running on your NAS.
 * [Wallabag](https://wallabag.org/) - Save and classify articles. Read them later.
 * [Watchtower](https://github.com/v2tec/watchtower) - Monitor your Docker containers and update them if a new version is available

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/docs/applications/unifi.md
+++ b/docs/applications/unifi.md
@@ -11,7 +11,7 @@ Set `unifi_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
 
 If you want to access Unifi externally, don't forget to set `unifi_available_externally: "true"` in your `inventories/<your_inventory>/nas.yml` file.
 
-The Unifi web interface can be found at http://ansible_nas_host_or_ip:8443.
+The Unifi web interface can be found at https://ansible_nas_host_or_ip:8443.
 
 ## Specific Configuration
 

--- a/docs/applications/unifi.md
+++ b/docs/applications/unifi.md
@@ -2,6 +2,7 @@
 # Unifi
 
 Homepage: [https://www.ui.com/software/](https://www.ui.com/software/)
+Docker Container: [https://hub.docker.com/r/linuxserver/unifi-controller](https://hub.docker.com/r/linuxserver/unifi-controller)
 
 The UniFi Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations  all controlled from a single interface.
 

--- a/docs/applications/unifi.md
+++ b/docs/applications/unifi.md
@@ -1,0 +1,18 @@
+
+# Unifi
+
+Homepage: [https://www.ui.com/software/](https://www.ui.com/software/)
+
+The UniFi Software-Defined Networking (SDN) platform is an end-to-end system of network devices across different locations  all controlled from a single interface.
+
+## Usage
+
+Set `unifi_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+If you want to access Unifi externally, don't forget to set `unifi_available_externally: "true"` in your `inventories/<your_inventory>/nas.yml` file.
+
+The Unifi web interface can be found at http://ansible_nas_host_or_ip:8443.
+
+## Specific Configuration
+
+The Unifi Controller runs in host mode and requires many ports; some of which are used by default by other apps. Before running Unifi you should read the Unifi section in group_vars/all.yml and change the ports of any conflicting apps you are using in your `inventories/<your_inventory>/nas.yml` file.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -59,14 +59,16 @@ By default, applications can be found on the ports listed below.
 | Ubooquity       | 2202   |              |
 | Ubooquity       | 2203   | Admin        |
 | Unifi           | 1900   | UDP          |
+| Unifi           | 5514   | TCP          |
 | Unifi           | 3478   | UDP          |
 | Unifi           | 10001  | UDP          |
 | Unifi           | 8080   | inform       | * Requires changing NextCloud default
-| Unifi           | 8081   |              | * Requires changing Sickchill default
+| Unifi           | 8081   | TCP          | * Requires changing Sickchill default
+| Unifi           | 8843   | TCP          |
 | Unifi           | 8443   | web inter    |
 | Unifi           | 8880   |              |
 | Unifi           | 6789   |              | * Requires changing NZBGet default
 | Unifi           | 27117  |              |
-| Unifi           | 10022  | SSH          | 
+| Unifi           | 10022  | SSH          |
 | Wallabag        | 7780   |              |
 | ZNC             | 6677   |              |

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -67,6 +67,6 @@ By default, applications can be found on the ports listed below.
 | Unifi           | 8880   |              |
 | Unifi           | 6789   |              | * Requires changing NZBGet default
 | Unifi           | 27117  |              |
-| Unifi           | 22     | SSH          | * Requires changing host SSH port (default=off)
+| Unifi           | 10022  | SSH          | 
 | Wallabag        | 7780   |              |
 | ZNC             | 6677   |              |

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -58,5 +58,15 @@ By default, applications can be found on the ports listed below.
 | Transmission    | 9092   |              |
 | Ubooquity       | 2202   |              |
 | Ubooquity       | 2203   | Admin        |
+| Unifi           | 1900   | UDP          |
+| Unifi           | 3478   | UDP          |
+| Unifi           | 10001  | UDP          |
+| Unifi           | 8080   | inform       | * Requires changing NextCloud default
+| Unifi           | 8081   |              | * Requires changing Sickchill default
+| Unifi           | 8443   | web inter    |
+| Unifi           | 8880   |              |
+| Unifi           | 6789   |              | * Requires changing NZBGet default
+| Unifi           | 27117  |              |
+| Unifi           | 22     | SSH          | * Requires changing host SSH port (default=off)
 | Wallabag        | 7780   |              |
 | ZNC             | 6677   |              |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -385,12 +385,12 @@ unifi_port_stun: "3478"                # UDP
 unifi_port_discovery: "10001"          # UDP
 unifi_port_inform: "8080"              # <- NextCloud default conflict, change NextCloud
 #unifi_port_b: "8081"                  # <- Sickchill default conflict, change Sickchill
-unifi_port_controller_gui_http: "8443" # <- only one you can change
+unifi_port_controller_gui_http: "8443" # <- you can change this
 unifi_port_redirect_https: "8843"
 unifi_port_redirect_http: "8880"
 unifi_port_throughput: "6789"          # <- NZBGet default conflict, change NZBGet
 unifi_port_database: "27117"
-#unifi_port_ssh: "22"                  # <- uncomment in unifi.yml if enabled
+unifi_port_ssh: "10022"                # <- you can change this
 
 ###
 ### Joomla

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -92,6 +92,9 @@ calibre_enabled: false
 # Ubooquity
 ubooquity_enabled: false
 
+# Unifi
+unifi_enabled: false
+
 # Joomla
 joomla_enabled: false
 
@@ -367,6 +370,27 @@ openvpn_username: leisure-suit-larry
 openvpn_password: secretpassword
 openvpn_provider: AWESOMEVPNPROVIDER
 openvpn_config: United-Kingdom
+
+###
+### Unifi
+###
+# REF: https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used
+unifi_available_externally: "false"
+unifi_data_directory: "{{ docker_home }}/unifi/config"
+unifi_user_id: "1000"
+unifi_group_id: "1000"
+# REF: https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used
+unifi_port_discoverable: "1900"        # UDP
+unifi_port_stun: "3478"                # UDP
+unifi_port_discovery: "10001"          # UDP
+unifi_port_inform: "8080"              # <- NextCloud default conflict, change NextCloud
+#unifi_port_b: "8081"                  # <- Sickchill default conflict, change Sickchill
+unifi_port_controller_gui_http: "8443" # <- only one you can change
+unifi_port_redirect_https: "8843"
+unifi_port_redirect_http: "8880"
+unifi_port_throughput: "6789"          # <- NZBGet default conflict, change NZBGet
+unifi_port_database: "27117"
+#unifi_port_ssh: "22"                  # <- uncomment in unifi.yml if enabled
 
 ###
 ### Joomla

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -374,22 +374,16 @@ openvpn_config: United-Kingdom
 ###
 ### Unifi
 ###
+# The Unifi Controller uses a number of ports that are uncofigurable, Unifi devices need to communicate on them.
+# The following apps must have their default ports changed:
+# NextCloud (8080), Sickchill (8081), and NZBGet (6789).
 # REF: https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used
 unifi_available_externally: "false"
 unifi_data_directory: "{{ docker_home }}/unifi/config"
+unifi_port_https: "8843"
+unifi_port_ssh: "10022"
 unifi_user_id: "1000"
 unifi_group_id: "1000"
-# REF: https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used
-unifi_port_discoverable: "1900"        # UDP
-unifi_port_stun: "3478"                # UDP
-unifi_port_discovery: "10001"          # UDP
-unifi_port_inform: "8080"              # <- NextCloud default conflict, change NextCloud
-#unifi_port_b: "8081"                  # <- Sickchill default conflict, change Sickchill
-unifi_port_redirect_https: "8843"      # <- you can change this
-unifi_port_redirect_http: "8880"
-unifi_port_throughput: "6789"          # <- NZBGet default conflict, change NZBGet
-unifi_port_database: "27117"
-unifi_port_ssh: "10022"                # <- you can change this
 
 ###
 ### Joomla

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -380,7 +380,7 @@ openvpn_config: United-Kingdom
 # REF: https://help.ubnt.com/hc/en-us/articles/218506997-UniFi-Ports-Used
 unifi_available_externally: "false"
 unifi_data_directory: "{{ docker_home }}/unifi/config"
-unifi_port_https: "8843"
+unifi_port_https: "8443"
 unifi_port_ssh: "10022"
 unifi_user_id: "1000"
 unifi_group_id: "1000"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -385,8 +385,7 @@ unifi_port_stun: "3478"                # UDP
 unifi_port_discovery: "10001"          # UDP
 unifi_port_inform: "8080"              # <- NextCloud default conflict, change NextCloud
 #unifi_port_b: "8081"                  # <- Sickchill default conflict, change Sickchill
-unifi_port_controller_gui_http: "8443" # <- you can change this
-unifi_port_redirect_https: "8843"
+unifi_port_redirect_https: "8843"      # <- you can change this
 unifi_port_redirect_http: "8880"
 unifi_port_throughput: "6789"          # <- NZBGet default conflict, change NZBGet
 unifi_port_database: "27117"

--- a/nas.yml
+++ b/nas.yml
@@ -228,6 +228,6 @@
     when: (unifi_enabled | default(False))
     tags: unifi
 
-- import_tasks: tasks/virtual_desktop.yml
+  - import_tasks: tasks/virtual_desktop.yml
     when: (virtual_desktop_enabled | default(False))
     tags: virtual_desktop

--- a/nas.yml
+++ b/nas.yml
@@ -224,6 +224,10 @@
     when: (serposcope_enabled | default(False))
     tags: serposcope
 
-  - import_tasks: tasks/virtual_desktop.yml
+  - import_tasks: tasks/unifi.yml
+    when: (unifi_enabled | default(False))
+    tags: unifi
+
+- import_tasks: tasks/virtual_desktop.yml
     when: (virtual_desktop_enabled | default(False))
     tags: virtual_desktop

--- a/nas.yml
+++ b/nas.yml
@@ -225,7 +225,11 @@
     tags: serposcope
 
   - import_tasks: tasks/unifi.yml
-    when: (unifi_enabled | default(False))
+    when:
+      - (unifi_enabled | default(False))
+      - not nextcloud_port == "8080"
+      - not sickchill_port == "8081"
+      - not nzbget_port == "6789"
     tags: unifi
 
   - import_tasks: tasks/virtual_desktop.yml

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -1,0 +1,38 @@
+---
+- name: Create Unifi Controller Config Directory
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ unifi_data_directory }}"
+
+- name: Unifi Controller Docker
+  docker_container:
+    name: unifi-controller
+    image: linuxserver/unifi-controller
+    pull: true
+    volumes:
+      - "{{ unifi_data_directory }}:/config:rw"
+    ports:
+#      - "{{ unifi_port_discoverable }}:1900/udp"
+      - "{{ unifi_port_stun }}:3478/udp"
+      - "{{ unifi_port_discovery }}:10001/udp"
+      - "{{ unifi_port_inform }}:8080"              # Nextcloud default port
+#      - "{{ unifi_port_b }}:8081"                  # Sickchill default port
+      - "{{ unifi_port_controller_gui_http }}:8443"
+      - "{{ unifi_port_redirect_https }}:8843"
+      - "{{ unifi_port_redirect_http }}:8880"
+      - "{{ unifi_port_throughput }}:6789"          # NZBGet default port
+      - "{{ unifi_port_database }}:27117"
+#      - "{{ unfi_port_ssh }}:22"                   # (host) SSH default port
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ unifi_user_id }}"
+      PGID: "{{ unifi_group_id }}"
+    restart_policy: unless-stopped
+    memory: 1g
+    labels:
+      traefik.backend: "unifi"
+      traefik.frontend.rule: "Host:unifi{{ ansible_nas_domain }}"
+      traefik.enable: "{{ unifi_available_externally }}"
+      traefik.port: "{{ unifi_port_controller_gui_http }}"

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -24,7 +24,7 @@
       - "{{ unifi_port_redirect_http }}:8880"
       - "{{ unifi_port_throughput }}:6789"          # NZBGet default port
       - "{{ unifi_port_database }}:27117"
-      - "{{ unfi_port_ssh }}:22"
+      - "{{ unifi_port_ssh }}:22"
     env:
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ unifi_user_id }}"

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -35,6 +35,6 @@
     memory: 1g
     labels:
       traefik.backend: "unifi"
-      traefik.frontend.rule: "Host:unifi{{ ansible_nas_domain }}"
+      traefik.frontend.rule: "Host:unifi.{{ ansible_nas_domain }}"
       traefik.enable: "{{ unifi_available_externally }}"
-      traefik.port: "8880"
+      traefik.port: "8443"

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -14,16 +14,19 @@
     volumes:
       - "{{ unifi_data_directory }}:/config:rw"
     ports:
-#      - "{{ unifi_port_discoverable }}:1900/udp"
-      - "{{ unifi_port_stun }}:3478/udp"
-      - "{{ unifi_port_discovery }}:10001/udp"
-      - "{{ unifi_port_inform }}:8080"              # Nextcloud default port
-#      - "{{ unifi_port_b }}:8081"                  # Sickchill default port
-      - "{{ unifi_port_redirect_https }}:8843"
-      - "{{ unifi_port_redirect_http }}:8880"
-      - "{{ unifi_port_throughput }}:6789"          # NZBGet default port
-      - "{{ unifi_port_database }}:27117"
+      - "1900:1900/udp"                        # Port used for "Make controller discoverable on L2 network"
+      - "5514:5514"                            # Port used for remote syslog capture.
+      - "3478:3478/udp"                        # Port used for STUN.
+      - "10001:10001/udp"                      # Port used for device discovery
+      - "8080:8080"                            # Port used for device and controller communication.
+      - "8081:8081"                            # unifi.shutdown.port
+      - "8443:8443"                            # Port used for controller GUI/API as seen in a web browser
+      - "{{ unifi_port_https }}:8843"          # Port used for HTTPS portal redirection.
+      - "8880:8880"                            # Port used for HTTP portal redirection.
+      - "6789:6789"                            # Port used for UniFi mobile speed test.
+      - "27117:27117"                          # Port used for local-bound database communication.
       - "{{ unifi_port_ssh }}:22"
+# UDP ports 5656-5699 for AP-EDU broadcasting not enabled
     env:
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ unifi_user_id }}"
@@ -34,4 +37,4 @@
       traefik.backend: "unifi"
       traefik.frontend.rule: "Host:unifi{{ ansible_nas_domain }}"
       traefik.enable: "{{ unifi_available_externally }}"
-      traefik.port: "{{ unifi_port_controller_gui_http }}"
+      traefik.port: "8880"

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -19,7 +19,6 @@
       - "{{ unifi_port_discovery }}:10001/udp"
       - "{{ unifi_port_inform }}:8080"              # Nextcloud default port
 #      - "{{ unifi_port_b }}:8081"                  # Sickchill default port
-      - "{{ unifi_port_controller_gui_http }}:8443"
       - "{{ unifi_port_redirect_https }}:8843"
       - "{{ unifi_port_redirect_http }}:8880"
       - "{{ unifi_port_throughput }}:6789"          # NZBGet default port

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -24,7 +24,7 @@
       - "{{ unifi_port_redirect_http }}:8880"
       - "{{ unifi_port_throughput }}:6789"          # NZBGet default port
       - "{{ unifi_port_database }}:27117"
-#      - "{{ unfi_port_ssh }}:22"                   # (host) SSH default port
+      - "{{ unfi_port_ssh }}:22"
     env:
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ unifi_user_id }}"

--- a/tasks/unifi.yml
+++ b/tasks/unifi.yml
@@ -20,8 +20,8 @@
       - "10001:10001/udp"                      # Port used for device discovery
       - "8080:8080"                            # Port used for device and controller communication.
       - "8081:8081"                            # unifi.shutdown.port
-      - "8443:8443"                            # Port used for controller GUI/API as seen in a web browser
-      - "{{ unifi_port_https }}:8843"          # Port used for HTTPS portal redirection.
+      - "8843:8843"                            # Port used for HTTPS portal redirection.
+      - "{{ unifi_port_https }}:8443"          # Port used for controller GUI/API as seen in a web browser
       - "8880:8880"                            # Port used for HTTP portal redirection.
       - "6789:6789"                            # Port used for UniFi mobile speed test.
       - "27117:27117"                          # Port used for local-bound database communication.

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -217,5 +217,6 @@ onDemand = false # create certificate when container is created
           "transmission.{{ ansible_nas_domain }}",
           "transmission-openvpn.{{ ansible_nas_domain }}",
           "ubooquity.{{ ansible_nas_domain }}",
+          "unifi.{{ ansible_nas_domain }}",
           "wallabag.{{ ansible_nas_domain }}",
           "znc.{{ ansible_nas_domain }}"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the popular Ubiquiti Unifi Controller to Ansible-NAS.

**Which issue (if any) this PR fixes**:

Fixes # https://github.com/davestephens/ansible-nas/issues/153

**Any other useful info**:

Unfortunately complex - but Ansible-NAS users should be abled enough.
