### PR TITLE
ADDITION: netboot.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Ansible config and a bunch of Docker containers.
 * A dual panel local file manager
 * Self-service media request web application
 * SEO tracking with Serposcope
+* A PXE server to boot OS images over the network
 
 ### Available Applications
 
@@ -60,6 +61,7 @@ Ansible config and a bunch of Docker containers.
 * [Miniflux](https://miniflux.app/) - An RSS news reader
 * [Mosquitto](https://mosquitto.org) - An open source MQTT broker
 * [MyMediaForAlexa](https://www.mymediaalexa.com/) - Lets you stream your music collection to your alexa device
+* [netboot.xyz](https://netboot.xyz/) - a PXE boot server
 * [Netdata](https://my-netdata.io/) - An extremely comprehensive system monitoring solution
 * [Nextcloud](https://nextcloud.com/) - A self-hosted Dropbox alternative
 * [NZBget](https://nzbget.net/) - The most efficient usenet downloader

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/docs/applications/netbootxyz.md
+++ b/docs/applications/netbootxyz.md
@@ -1,0 +1,14 @@
+
+# netboot.xyz
+
+Homepage: [https://netboot.xyz/](https://netboot.xyz/)
+
+netboot.xyz is a way to PXE boot various operating system installers or utilities from one place within the BIOS without the need of having to go retrieve the media to run the tool. [iPXE](https://ipxe.org/) is used to provide a user friendly menu from within the BIOS that lets you easily choose the operating system you want along with any specific types of versions or bootable flags.
+
+You can remote attach the ISO to servers, set it up as a rescue option in Grub, or even set up your home network to boot to it by default so that it's always available.
+
+## Usage
+
+Set `netbootxyz_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The netbooxyz web interface can be found at http://ansible_nas_host_or_ip:3002.

--- a/docs/applications/netbootxyz.md
+++ b/docs/applications/netbootxyz.md
@@ -2,6 +2,7 @@
 # netboot.xyz
 
 Homepage: [https://netboot.xyz/](https://netboot.xyz/)
+Docker Container: [https://hub.docker.com/r/linuxserver/netbootxyz](https://hub.docker.com/r/linuxserver/netbootxyz)
 
 netboot.xyz is a way to PXE boot various operating system installers or utilities from one place within the BIOS without the need of having to go retrieve the media to run the tool. [iPXE](https://ipxe.org/) is used to provide a user friendly menu from within the BIOS that lets you easily choose the operating system you want along with any specific types of versions or bootable flags.
 

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -36,6 +36,9 @@ By default, applications can be found on the ports listed below.
 | Mosquitto       | 1883   | MQTT         |
 | Mosquitto       | 9001   | Websocket    |
 | MyMediaForAlexa | 52051  |              |
+| netbootxyz      | 3002   | HTTP         |
+| netbootxyz      | 5803   | HTTP         |
+| netbootxyz      | 69     | TFTP         |
 | Netdata         | 19999  |              |
 | Nextcloud       | 8080   |              |
 | NZBGet          | 6789   |              |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -52,6 +52,7 @@ portainer_enabled: false
 glances_enabled: false
 stats_enabled: false
 guacamole_enabled: false
+netbootxyz_enabled: false
 netdata_enabled: false
 watchtower_enabled: false
 cloudflare_ddns_enabled: false
@@ -524,6 +525,17 @@ ombi_available_externally: "false"
 ombi_config_directory: "{{ docker_home }}/ombi/config"
 ombi_user_id: "0"
 ombi_group_id: "0"
+
+###
+### netbootxyz
+###
+netbootxyz_available_externally: "false"
+netbootxyz_data_directory: "{{ docker_home }}/netbootxyz"
+netbootxyz_port_http: "3002"
+netbootxyz_port_http2: "5803"
+netbootxyz_port_tftp: "69"
+netbootxyz_user_id: "1000"
+netbootxyz_group_id: "1000"
 
 ###
 ### Netdata

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -530,7 +530,8 @@ ombi_group_id: "0"
 ### netbootxyz
 ###
 netbootxyz_available_externally: "false"
-netbootxyz_data_directory: "{{ docker_home }}/netbootxyz"
+netbootxyz_config_directory: "{{ docker_home }}/netbootxyz/config"
+netbootxyz_assets_directory: "{{ docker_home }}/netbootxyz/assets"
 netbootxyz_port_http: "3002"
 netbootxyz_port_http2: "5803"
 netbootxyz_port_tftp: "69"

--- a/nas.yml
+++ b/nas.yml
@@ -112,6 +112,10 @@
     when: (miniflux_enabled | default(False))
     tags: miniflux
 
+  - import_tasks: tasks/netbootxyz.yml
+    when: (netbootxyz_enabled | default(False))
+    tags: netbootxyz
+
   - import_tasks: tasks/nextcloud.yml
     when: (nextcloud_enabled | default(False))
     tags: nextcloud

--- a/tasks/netbootxyz.yml
+++ b/tasks/netbootxyz.yml
@@ -5,8 +5,8 @@
     path: "{{ item }}"
     state: directory
   with_items:
-    - "{{ netbootxyz_data_directory }}/config"
-    - "{{ netbootxyz_data_directory }}/assets"
+    - "{{ netbootxyz_config_directory }}"
+    - "{{ netbootxyz_assets_directory }}"
 
 - name: netbootxyz Docker Container
   docker_container:
@@ -14,8 +14,8 @@
     image: linuxserver/netbootxyz:latest
     pull: true
     volumes:
-      - "{{ netbootxyz_data_directory }}/config:/config:rw"
-      - "{{ netbootxyz_data_directory }}/assets:/assets:rw"
+      - "{{ netbootxyz_config_directory }}:/config:rw"
+      - "{{ netbootxyz_assets_directory }}:/assets:rw"
     ports:
       - "{{ netbootxyz_port_http }}:3000"
       - "{{ netbootxyz_port_http2 }}:80"

--- a/tasks/netbootxyz.yml
+++ b/tasks/netbootxyz.yml
@@ -1,0 +1,33 @@
+
+---
+- name: netbootxyz Directory
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ netbootxyz_data_directory }}/config"
+    - "{{ netbootxyz_data_directory }}/assets"
+
+- name: netbootxyz Docker Container
+  docker_container:
+    name: netbootxyz
+    image: linuxserver/netbootxyz:latest
+    pull: true
+    volumes:
+      - "{{ netbootxyz_data_directory }}/config:/config:rw"
+      - "{{ netbootxyz_data_directory }}/assets:/assets:rw"
+    ports:
+      - "{{ netbootxyz_port_http }}:3000"
+      - "{{ netbootxyz_port_http2 }}:80"
+      - "{{ netbootxyz_port_tftp }}:69/udp"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ netbootxyz_user_id }}"
+      PGID: "{{ netbootxyz_group_id }}"
+    restart_policy: unless-stopped
+    labels:
+      traefik.backend: "netbootxyz"
+      traefik.frontend.rule: "Host:netbootxyz.{{ ansible_nas_domain }}"
+      traefik.enable: "{{ netbootxyz_available_externally }}"
+      traefik.port: "80"
+    memory: 1g


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds netboot.xyz PXE server to Ansible-NAS

**Which issue (if any) this PR fixes**:

Fixes # https://github.com/davestephens/ansible-nas/issues/146

**Any other useful info**:
