### PR TITLE
BUG: Transmission UDP fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/tasks/transmission.yml
+++ b/tasks/transmission.yml
@@ -21,6 +21,7 @@
     ports:
       - "{{ transmission_webui_port }}:9091"
       - "{{ transmission_external_port }}:51413"
+      - "{{ transmission_external_port }}:51413/udp"
     env:
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ transmission_user_id }}"

--- a/tasks/transmission_with_openvpn.yml
+++ b/tasks/transmission_with_openvpn.yml
@@ -23,6 +23,7 @@
     ports:
       - "{{ transmission_openvpn_webui_port }}:9091"
       - "{{ transmission_openvpn_external_port }}:51413"
+      - "{{ transmission_openvpn_external_port }}:51413/udp"
       - "{{ transmission_openvpn_proxy_port }}:3128"
     env:
       TRANSMISSION_HOME: "/config"


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes the UDP port, same as the TCP port (transmission_external_port/transmission_openvpn_external_port), to allow DHT use.

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:
I didn't see the need to update the ports list explicitly for the UDP addition as the TCP port is already there. 