### PR TITLE
MiniDLNA - consistent and proper global naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Ansible config and a bunch of Docker containers.
 * [Jellyfin](https://jellyfin.github.io) - The Free Software Media System
 * [Joomla](https://www.joomla.org/) - Open source content management system
 * [Lidarr](https://github.com/lidarr/Lidarr) - Music collection manager for Usenet and BitTorrent users
-* [MiniDlna](https://sourceforge.net/projects/minidlna/) - simple media server which is fully compliant with DLNA/UPnP-AV clients
+* [MiniDLNA](https://sourceforge.net/projects/minidlna/) - simple media server which is fully compliant with DLNA/UPnP-AV clients
 * [Miniflux](https://miniflux.app/) - An RSS news reader
 * [Mosquitto](https://mosquitto.org) - An open source MQTT broker
 * [MyMediaForAlexa](https://www.mymediaalexa.com/) - Lets you stream your music collection to your alexa device

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
-* [Calibre](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
+* [Calibre-web](https://hub.docker.com/r/linuxserver/calibre-web) - eBook Library
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -668,7 +668,7 @@ timemachine_log_level: error
 timemachine_port: "10445"
 
 ###
-### minidlna
+### MiniDLNA
 ###
 minidlna_media_directory1: "{{ movies_root }}"
 minidlna_media_directory2: "{{ tv_root }}"

--- a/tasks/minidlna.yml
+++ b/tasks/minidlna.yml
@@ -1,4 +1,4 @@
-- name: minidlna Docker Container
+- name: MiniDLNA Docker Container
   docker_container:
     name: minidlna
     image: vladgh/minidlna


### PR DESCRIPTION

**What this PR does / why we need it**:

Fix inconsistent and wrong capitalization of the program MiniDLNA, of which "DLNA" is an acronym and should always be capitalized.

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

...one more of my pet peeves list, the RAGE continues...