### PR TITLE
ADDITION: TVHeadend

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Ansible config and a bunch of Docker containers.
 * [TimeMachine](https://github.com/awlx/samba-timemachine) - Samba-based mac backup server
 * [Traefik](https://traefik.io/) - Web proxy and SSL certificate manager
 * [Transmission](https://transmissionbt.com/) - BitTorrent client (with OpenVPN if you have a supported VPN provider)
+* [TVHeadend](https://tvheadend.org/) - TV streaming server and recorder
 * [Ubooquity](http://vaemendis.net/ubooquity/) - Book and comic server
 * [Virtual Desktop](https://github.com/RattyDAVE/docker-ubuntu-xrdp-mate-custom) - A virtual desktop running on your NAS.
 * [Wallabag](https://wallabag.org/) - Save and classify articles. Read them later.

--- a/docs/applications/tvheadend.md
+++ b/docs/applications/tvheadend.md
@@ -22,3 +22,9 @@ will then add the device / folder '/dev/dri' to the list of docker volumes. This
 
 If you want to pass a physical dvb tuner card, you can set `tvheadend_hw_dvb` to `true`. The play 
 will then add the device / folder '/dev/dvb' to the list of docker volumes. This is disabled by default.
+
+For discovery of local IPTV services, you may need to change the network mode of the docker container to
+ `host`, default is 'bridge'.
+
+It is possible to pin the version of the Docker images by setting `tvheadend_version` to the desired tag.
+ Note that the linuxserver.io images are used for TVHeadend.

--- a/docs/applications/tvheadend.md
+++ b/docs/applications/tvheadend.md
@@ -1,0 +1,24 @@
+# TVHeadend
+
+Homepage: [https://tvheadend.org/](https://tvheadend.org/)
+
+Tvheadend is a TV streaming server and recorder for Linux, FreeBSD and Android supporting DVB-S, 
+DVB-S2, DVB-C, DVB-T, ATSC, ISDB-T, IPTV, SAT>IP and HDHomeRun as input sources.
+
+## Usage
+
+Set `tvheadend_enabled: true` in your `inventories/<your_inventory>/nas.yml` file. There are further
+parameters you can edit such as `tvheadend_hw_accel` and `tvheadend_hw_dvb` lower down. 
+
+## Specific Configuration
+
+The TVHeadend web interface can be found at port 9981 (http) of your NAS.
+
+There is a dedicated folder / share for recordings that TVHeadend uses. You can change this by 
+setting `tvheadend_recordings_directory`.
+
+If you want to enable hardware acceleration, you can set `tvheadend_hw_accel` to `true`. The play 
+will then add the device / folder '/dev/dri' to the list of docker volumes. This is disabled by default.
+
+If you want to pass a physical dvb tuner card, you can set `tvheadend_hw_dvb` to `true`. The play 
+will then add the device / folder '/dev/dvb' to the list of docker volumes. This is disabled by default.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -58,6 +58,8 @@ By default, applications can be found on the ports listed below.
 | Transmission    | 9091   | with VPN     |
 | Transmission    | 3128   | http proxy   |
 | Transmission    | 9092   |              |
+| TVHeadend       | 9981   | HTTP         |
+| TVHeadend       | 9982   | HTSP         |
 | Ubooquity       | 2202   |              |
 | Ubooquity       | 2203   | Admin        |
 | Wallabag        | 7780   |              |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -929,3 +929,7 @@ tvheadend_port_htsp: "9982"
 tvheadend_hw_accel: false
 # If true, pass /dev/dvb for for dvb tuner cards to docker
 tvheadend_hw_dvb: false
+# Set to host for discovery of iptv (e.g. AVM Fritz DVB devices and so on)
+tvheadend_network_mode: "bridge"
+# Allow to set the version (docker tag)
+tvheadend_version: "latest"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -861,6 +861,6 @@ tvheadend_group_id: "0"
 tvheadend_port_web: "9981"
 tvheadend_port_htsp: "9982"
 # If true, pass /dev/dri for hardware acceleration as volume to docker
-tvheadend_hw_accel: "false"
+tvheadend_hw_accel: false
 # If true, pass /dev/dvb for for dvb tuner cards to docker
-tvheadend_hw_dvb: "false"
+tvheadend_hw_dvb: false

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -39,6 +39,9 @@ bazarr_enabled: false
 ombi_enabled: false
 lidarr_enabled: false
 
+# Media recording
+tvheadend_enabled: false
+
 # Music
 airsonic_enabled: false
 mymediaforalexa_enabled: false
@@ -159,6 +162,9 @@ movies_root: "{{ samba_shares_root }}/movies"
 # Where your TV episodes are stored
 tv_root: "{{ samba_shares_root }}/tv"
 
+# Where your PVR recordings are stored
+recordings_root: "{{ samba_shares_root }}/recordings"
+
 # Where torrent files are stored (picked up by Transmission for downloading)
 torrents_root: "{{ samba_shares_root }}/torrents"
 
@@ -205,6 +211,14 @@ samba_shares:
     writable: yes
     browsable: yes
     path: "{{ tv_root }}"
+
+  - name: recordings
+    comment: 'Recordings'
+    guest_ok: yes
+    public: yes
+    writable: yes
+    browsable: yes
+    path: "{{ recordings_root }}"
 
   - name: music
     comment: 'Music'
@@ -837,3 +851,18 @@ vd_users:
     password: "topsecret"
     sudo: "Y"
 vd_rdp_port: 3389
+
+###
+### TVHeadend
+###
+tvheadend_available_externally: "false"
+tvheadend_config_directory: "{{ docker_home }}/tvheadend/config"
+tvheadend_recordings_directory: "{{ recordings_root }}"
+tvheadend_user_id: "0"
+tvheadend_group_id: "0"
+tvheadend_port_web: "9981"
+tvheadend_port_htsp: "9982"
+# You may add the following volumes
+#   - /dev/dri:/dev/dri # hardware accelerated video processing
+#   - /dev/dvb:/dev/dvb # pass tv tuner card
+tvheadend_additional_volumes: []

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -38,8 +38,6 @@ emby_enabled: false
 bazarr_enabled: false
 ombi_enabled: false
 lidarr_enabled: false
-
-# Media recording
 tvheadend_enabled: false
 
 # Music
@@ -862,7 +860,7 @@ tvheadend_user_id: "0"
 tvheadend_group_id: "0"
 tvheadend_port_web: "9981"
 tvheadend_port_htsp: "9982"
-# You may add the following volumes
-#   - /dev/dri:/dev/dri # hardware accelerated video processing
-#   - /dev/dvb:/dev/dvb # pass tv tuner card
-tvheadend_additional_volumes: []
+# If true, pass /dev/dri for hardware acceleration as volume to docker
+tvheadend_hw_accel: "false"
+# If true, pass /dev/dvb for for dvb tuner cards to docker
+tvheadend_hw_dvb: "false"

--- a/nas.yml
+++ b/nas.yml
@@ -231,3 +231,7 @@
   - import_tasks: tasks/virtual_desktop.yml
     when: (virtual_desktop_enabled | default(False))
     tags: virtual_desktop
+
+  - import_tasks: tasks/tvheadend.yml
+    when: (tvheadend_enabled | default(False))
+    tags: tvheadend

--- a/tasks/tvheadend.yml
+++ b/tasks/tvheadend.yml
@@ -1,19 +1,17 @@
-# Some indirection to be able to extend the volumes list conditionally
-- name: Define basic docker volumes
+# Some indirection to be able to extend the devices list conditionally
+- name: Define basic docker devices
   set_fact:
-    tvheadend_docker_volumes:
-      - "{{ tvheadend_config_directory }}:/config:rw"
-      - "{{ tvheadend_recordings_directory }}:/recordings:rw"
+    tvheadend_docker_devices: []
 
 - name: Add hw acceleration
   set_fact:
-    tvheadend_docker_volumes: "{{ tvheadend_docker_volumes + [ '/dev/dri:/dev/dri' ] }}"
-  when: tvheadend_hw_accel == "true"
+    tvheadend_docker_devices: "{{ tvheadend_docker_devices + [ '/dev/dri:/dev/dri' ] }}"
+  when: tvheadend_hw_accel
 
 - name: Add dvb hw
   set_fact:
-    tvheadend_docker_volumes: "{{ tvheadend_docker_volumes + [ '/dev/dvb:/dev/dvb' ] }}"
-  when: tvheadend_hw_dvb == "true"
+    tvheadend_docker_devices: "{{ tvheadend_docker_devices + [ '/dev/dvb:/dev/dvb' ] }}"
+  when: tvheadend_hw_dvb
 
 - name: Create TVHeadend Directories
   file:
@@ -27,7 +25,10 @@
     name: tvheadend
     image: linuxserver/tvheadend
     pull: true
-    volumes: "{{ tvheadend_docker_volumes }}"
+    volumes:
+      - "{{ tvheadend_config_directory }}:/config:rw"
+      - "{{ tvheadend_recordings_directory }}:/recordings:rw"
+    devices: "{{ tvheadend_docker_devices | default([]) }}"
     network_mode: host # enables discovery of IPTV
     ports:
       - "{{ tvheadend_port_web }}:9981"

--- a/tasks/tvheadend.yml
+++ b/tasks/tvheadend.yml
@@ -13,6 +13,13 @@
     tvheadend_docker_devices: "{{ tvheadend_docker_devices + [ '/dev/dvb:/dev/dvb' ] }}"
   when: tvheadend_hw_dvb
 
+- name: Define docker ports if network mode is bridge
+  set_fact:
+    tvheadend_docker_ports:
+      - "{{ tvheadend_port_web }}:9981"
+      - "{{ tvheadend_port_htsp }}:9982"
+  when: "'bridge' in tvheadend_network_mode"
+
 - name: Create TVHeadend Directories
   file:
     path: "{{ item }}"
@@ -23,16 +30,14 @@
 - name: TVHeadend Docker Container
   docker_container:
     name: tvheadend
-    image: linuxserver/tvheadend
+    image: "linuxserver/tvheadend:{{ tvheadend_version }}"
     pull: true
     volumes:
       - "{{ tvheadend_config_directory }}:/config:rw"
       - "{{ tvheadend_recordings_directory }}:/recordings:rw"
     devices: "{{ tvheadend_docker_devices | default([]) }}"
-    network_mode: host # enables discovery of IPTV
-    ports:
-      - "{{ tvheadend_port_web }}:9981"
-      - "{{ tvheadend_port_htsp }}:9982"
+    network_mode: "{{ tvheadend_network_mode }}"
+    ports: "{{ tvheadend_docker_ports | default([]) }}"
     env:
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ tvheadend_user_id }}"

--- a/tasks/tvheadend.yml
+++ b/tasks/tvheadend.yml
@@ -1,3 +1,20 @@
+# Some indirection to be able to extend the volumes list conditionally
+- name: Define basic docker volumes
+  set_fact:
+    tvheadend_docker_volumes:
+      - "{{ tvheadend_config_directory }}:/config:rw"
+      - "{{ tvheadend_recordings_directory }}:/recordings:rw"
+
+- name: Add hw acceleration
+  set_fact:
+    tvheadend_docker_volumes: "{{ tvheadend_docker_volumes + [ '/dev/dri:/dev/dri' ] }}"
+  when: tvheadend_hw_accel == "true"
+
+- name: Add dvb hw
+  set_fact:
+    tvheadend_docker_volumes: "{{ tvheadend_docker_volumes + [ '/dev/dvb:/dev/dvb' ] }}"
+  when: tvheadend_hw_dvb == "true"
+
 - name: Create TVHeadend Directories
   file:
     path: "{{ item }}"
@@ -10,10 +27,8 @@
     name: tvheadend
     image: linuxserver/tvheadend
     pull: true
-    volumes:
-      - "{{ tvheadend_config_directory }}:/config:rw"
-      - "{{ tvheadend_recordings_directory }}:/recordings:rw"
-    network_mode: host # discovery of IPTV
+    volumes: "{{ tvheadend_docker_volumes }}"
+    network_mode: host # enables discovery of IPTV
     ports:
       - "{{ tvheadend_port_web }}:9981"
       - "{{ tvheadend_port_htsp }}:9982"

--- a/tasks/tvheadend.yml
+++ b/tasks/tvheadend.yml
@@ -1,0 +1,30 @@
+- name: Create TVHeadend Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ tvheadend_config_directory }}"
+
+- name: TVHeadend Docker Container
+  docker_container:
+    name: tvheadend
+    image: linuxserver/tvheadend
+    pull: true
+    volumes:
+      - "{{ tvheadend_config_directory }}:/config:rw"
+      - "{{ tvheadend_recordings_directory }}:/recordings:rw"
+    network_mode: host # discovery of IPTV
+    ports:
+      - "{{ tvheadend_port_web }}:9981"
+      - "{{ tvheadend_port_htsp }}:9982"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ tvheadend_user_id }}"
+      PGID: "{{ tvheadend_group_id }}"
+    restart_policy: unless-stopped
+    memory: 1g
+    labels:
+      traefik.backend: "tvheadend"
+      traefik.frontend.rule: "Host:tvheadend.{{ ansible_nas_domain }}"
+      traefik.enable: "{{ tvheadend_available_externally }}"
+      traefik.port: "9981"

--- a/templates/traefik/traefik.toml
+++ b/templates/traefik/traefik.toml
@@ -217,6 +217,7 @@ onDemand = false # create certificate when container is created
           "thelounge.{{ ansible_nas_domain }}",
           "transmission.{{ ansible_nas_domain }}",
           "transmission-openvpn.{{ ansible_nas_domain }}",
+          "tvheadend.{{ ansible_nas_domain }}",
           "ubooquity.{{ ansible_nas_domain }}",
           "wallabag.{{ ansible_nas_domain }}",
           "znc.{{ ansible_nas_domain }}"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds TVHeadend as an installable service via Ansible and Docker. TVHeadend is a streaming and recording server for television broadcasting and can be used with different backends, like IPTV, DVB tuner cards and so on.


**Which issue (if any) this PR fixes**:

 #325 

**Any other useful info**:

Though I think the PR is ready as it is (and tested locally), there are still some thoughts I have:

- I added a new directory / share for recordings, because I think the "tv" folder does not quite fit the needs of TVHeadend which not only records series. I'm open for other opinions here.
- DVB drivers / firmware: I wasn't sure whether to include tasks for installing DVB drivers and firmware. For my personal hardware (WinTV Quad HD), I would need, for example, the Hauppauge ppa and the Linux media tree (see https://hauppauge.com/pages/support/support_linux.html#ppa). As this is very specific to the users hardware, I currently see this out of scope for ansible-nas.