### PR TITLE
DOCS (Krusader): fixed link instead of name error (glad to fix my mistakes!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Ansible config and a bunch of Docker containers.
 * [Jackett](https://github.com/Jackett/Jackett) - API Support for your favorite torrent trackers
 * [Jellyfin](https://jellyfin.github.io) - The Free Software Media System
 * [Joomla](https://www.joomla.org/) - Open source content management system
-* [https://krusader.org/](https://krusader.org/) - Twin panel file management for your desktop
+* [Krusader](https://krusader.org/) - Twin panel file management for your desktop
 * [Lidarr](https://github.com/lidarr/Lidarr) - Music collection manager for Usenet and BitTorrent users
 * [MiniDlna](https://sourceforge.net/projects/minidlna/) - simple media server which is fully compliant with DLNA/UPnP-AV clients
 * [Miniflux](https://miniflux.app/) - An RSS news reader


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix README.md mistake

**Which issue (if any) this PR fixes**:

Fixes # Krusader addition

**Any other useful info**:
