### PR TITLE
CONTAINER CHANGE: Watchtower to use creator/maintainer's container

### DIFF
--- a/tasks/watchtower.yml
+++ b/tasks/watchtower.yml
@@ -2,7 +2,7 @@
 - name: Watchtower Docker Container
   docker_container:
     name: watchtower
-    image: v2tec/watchtower
+    image: containrrr/watchtower
     pull: true
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"


### PR DESCRIPTION

**What this PR does / why we need it**:

Current container used (v2tec/watchtower) hasn't been updated in two years. 
Meanwhile, containnrrr/watchtower, is the developer's container and updated regularly (as recent as a week ago). Also supports more notifications (e.g. Gotify and another just got merged into the watchtower codebase recently as well).

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

GOTIFY SUPPORT!