### PR TITLE
BUG: CloudCMD - fix "config" dir to point to /root where .cloudcmd.json is located

### DIFF
--- a/tasks/cloudcmd.yml
+++ b/tasks/cloudcmd.yml
@@ -12,7 +12,7 @@
     image: coderaiser/cloudcmd
     pull: true
     volumes:
-      - "{{ cloudcmd_data_directory }}:/config:rw"
+      - "{{ cloudcmd_data_directory }}:/root:rw"
       - "{{ cloudcmd_browse_directory }}:/mnt/fs"
     ports:
       - "{{ cloudcmd_port }}:8000"


### PR DESCRIPTION
**What this PR does / why we need it**:

Ever tried to set a password on your instance of CloudCMD in AN? If you did, you'll never get back into it again. Don't believe me? Try it!

This fix points the "config" directory to /root (home) of the Docker container where the .cloudcmd.json configuration file is located. Now you can set a password (and change any of the variables in the .json) and they will work and "stick."

**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

I'd REALLY like to prefer to change cloudcmd_data_directory: "{{ docker_home }}/cloudcmd/config" to cloudcmd_data_directory: "{{ docker_home }}/cloudcmd" and then make a root dir below that in the task and mount the volume there. 

DISCLAIMER: There are other files in the container /root dir that won't transfer/be used (I think there were 3-4). There is also a .cloudcmd.json in the current config dir. After changing the volume, CloudCMD continued to work and filled in the missing variables in the existing config/.cloudcmd.json file. The other files were not created. CloudCMD appears to be running fine with all defaults for me as well as the auth credentials I inserted.
