### PR TITLE
BUG: (YOUTUBEDL-MATERIAL) - path fix

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -553,7 +553,7 @@ lidarr_port: "8686"
 youtubedlmaterial_available_externally: "false"
 youtubedlmaterial_data_directory: "{{ docker_home }}/youtubedlmaterial"
 youtubedlmaterial_dl_audio_directory: "{{ downloads_root }}/youtube/audio"
-youtubedlmaterial_dl_video_directory: "{{ downloads_root }}youtube/video"
+youtubedlmaterial_dl_video_directory: "{{ downloads_root }}/youtube/video"
 youtubedlmaterial_dl_subscriptions_directory: "{{ downloads_root }}/youtube/subscriptions"
 youtubedlmaterial_port_http: "8998"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a missing slash in default download location for videos.

@xerosanyam - thanks for noticing this!

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

Fixing my mistakes!