### PR TITLE
replaced cloudflare-ddns

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -287,17 +287,26 @@ nfs_exports:
 # Cloudflare is a great free DNS option for domains. If you use the cloudflare_ddns container then you'll need to
 # set the options below.
 
-# Your domain name
+# Your domain name (in the free subscription this is always your TLD such as example.com)
 cloudflare_zone: "{{ ansible_nas_domain }}"
 
-# The hostname you want the container to update. You shouldn't need to change this.
-cloudflare_host: "*.{{ cloudflare_zone }}"
+# The hostname/subdomain you want the container to update.
+# To register a hostname use "{{ ansible_nas_hostname }}.{{ cloudflare_zone }}"
+# To register a subdomain use "*.<subdomain>.{{ cloudflare_zone }}"
+# To forward any use "*.{{ cloudflare_zone }}"
+cloudflare_subdomain: "*.{{ cloudflare_zone }}"
 
-# Email address used to register for Cloudflare
-cloudflare_email: "{{ ansible_nas_email }}"
-
-# Cloudflare 'Global API Key', can be found on the 'My Profile' page
+# Cloudflare 'Global API Key', can be found on the 'My Profile' page (see https://github.com/oznu/docker-cloudflare-ddns#creating-a-cloudflare-api-token)
 cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
+
+# Set to true to have the dns record deleted when the container is stopped.
+cloudflare_delete_on_stop: "false"
+
+# Set to true to make traffic go through the CloudFlare CDN.
+cloudflare_proxy: "false"
+
+# Set to AAAA to use set IPv6 records instead of IPv4 records.
+cloudflare_type: "A"
 
 ###
 ### General

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -294,10 +294,10 @@ cloudflare_zone: "{{ ansible_nas_domain }}"
 # To register a hostname use "{{ ansible_nas_hostname }}.{{ cloudflare_zone }}"
 # To register a subdomain use "*.<subdomain>.{{ cloudflare_zone }}"
 # To forward any use "*.{{ cloudflare_zone }}"
-cloudflare_subdomain: "*.{{ cloudflare_zone }}"
+cloudflare_subdomain: "{{ ansible_nas_hostname }}.{{ cloudflare_zone }}"
 
-# Cloudflare 'Global API Key', can be found on the 'My Profile' page (see https://github.com/oznu/docker-cloudflare-ddns#creating-a-cloudflare-api-token)
-cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
+# Cloudflare 'API Token', can be created on the 'My Profile'->'API Tokens' page (see https://github.com/oznu/docker-cloudflare-ddns#creating-a-cloudflare-api-token)
+cloudflare_api_token: abcdeabcdeabcdeabcde1234512345
 
 # Set to true to have the dns record deleted when the container is stopped.
 cloudflare_delete_on_stop: "false"

--- a/tasks/cloudflare_ddns.yml
+++ b/tasks/cloudflare_ddns.yml
@@ -7,7 +7,7 @@
     env:
       ZONE: "{{ cloudflare_zone }}"
       SUBDOMAIN: "{{ cloudflare_subdomain }}"
-      API_KEY: "{{ cloudflare_api_key }}"
+      API_KEY: "{{ cloudflare_api_token }}"
       PROXIED: "{{ cloudflare_proxy }}"
       RRTYPE: "{{ cloudflare_type }}"
       DELETE_ON_STOP: "{{ cloudflare_delete_on_stop }}"

--- a/tasks/cloudflare_ddns.yml
+++ b/tasks/cloudflare_ddns.yml
@@ -1,14 +1,15 @@
 - name: Cloudflare Dynamic DNS Container
   docker_container:
     name: cloudflare-ddns
-    image: joshava/cloudflare-ddns:latest
+    image: oznu/cloudflare-ddns:latest
     pull: true
+    network_mode: host
     env:
       ZONE: "{{ cloudflare_zone }}"
-      HOST: "{{ cloudflare_host }}"
-      EMAIL: "{{ cloudflare_email }}"
-      API: "{{ cloudflare_api_key }}"
-      PROXY: "false"
+      SUBDOMAIN: "{{ cloudflare_subdomain }}"
+      API_KEY: "{{ cloudflare_api_key }}"
+      PROXIED: "{{ cloudflare_proxy }}"
+      RRTYPE: "{{ cloudflare_type }}"
+      DELETE_ON_STOP: "{{ cloudflare_delete_on_stop }}"
     restart_policy: unless-stopped
     memory: 512MB
-


### PR DESCRIPTION
**What this PR does / why we need it**:
I ran into bug #243 and tried to fix it. After some research I replaced the docker container with cloudflare-ddns from [oznu](https://hub.docker.com/r/oznu/cloudflare-ddns), which seems to be more popular (10M+ downloads vs. 5M downloads on docker hub). But for me it was much more important that the code was easier to understand.

**Which issue (if any) this PR fixes**:
Fixes #243

**Any other useful info**:
`network_mode: host` is required for IPv6 to work properly.
