### PR TITLE
Fix YoutubeDL-Material links

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Ansible config and a bunch of Docker containers.
 * [Virtual Desktop](https://github.com/RattyDAVE/docker-ubuntu-xrdp-mate-custom) - A virtual desktop running on your NAS.
 * [Wallabag](https://wallabag.org/) - Save and classify articles. Read them later.
 * [Watchtower](https://github.com/v2tec/watchtower) - Monitor your Docker containers and update them if a new version is available
-* [YouTubeDL-Material](https://ytdl-org.github.io/youtube-dl) - Self-hosted YouTube downloader built on Material Design
+* [YouTubeDL-Material](https://github.com/Tzahi12345/YoutubeDL-Material) - Self-hosted YouTube downloader built on Material Design
 * [ZNC](https://wiki.znc.in/ZNC) - IRC bouncer to stay connected to favourite IRC networks and channels
 
 ## What This Could Do

--- a/docs/applications/youtubedlmaterial.md
+++ b/docs/applications/youtubedlmaterial.md
@@ -1,8 +1,8 @@
 
 # YouTubeDL-Material
 
-Homepage: [https://ytdl-org.github.io/youtube-dl/](https://ytdl-org.github.io/youtube-dl/)
-Docker Container: [https://github.com/Tzahi12345/YoutubeDL-Material](https://github.com/Tzahi12345/YoutubeDL-Material)
+Homepage: [https://github.com/Tzahi12345/YoutubeDL-Material](https://github.com/Tzahi12345/YoutubeDL-Material)
+Docker Container: [https://hub.docker.com/r/tzahi12345/youtubedl-material](https://hub.docker.com/r/tzahi12345/youtubedl-material)
 
 YoutubeDL-Material is a Material Design frontend for youtube-dl. It's coded using Angular 9 for the frontend, and Node.js on the backend.
 


### PR DESCRIPTION
Updated link to YoutubeDL-Material to the actual link (it was set to the youtube-dl project before)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

It fixes the link for YoutubeDL-Material, it was previously set to the youtube-dl home page. youtube-dl is the command-line utility that YoutubeDL-Material is based on, so the confusion is very understandable.

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:

N/A