### PR TITLE
Ubuntu 20.04 compatibility - fixes warning from ansible 2.96

### DIFF
--- a/tasks/general.yml
+++ b/tasks/general.yml
@@ -21,7 +21,7 @@
 
 - name: Upgrade all packages
   apt:
-    upgrade: true
+    upgrade: 'True'
     state: latest
   when: keep_packages_updated
   tags:


### PR DESCRIPTION
**What this PR does / why we need it**:

fixes warning from latest ansible ver
otherwise will give the following warning:
TASK [Upgrade all packages] ********************************************************************************************
[WARNING]: The value True (type bool) in a string field was converted to 'True' (type string). If this does not look
like what you expect, quote the entire value to ensure it does not change.
ok: [localhost]



**Which issue (if any) this PR fixes**:

Fixes # n/a

**Any other useful info**:

Related to https://github.com/davestephens/ansible-nas/issues/200