### PR TITLE
Cloudflare-ddns: fix broken configuration and update default auth from deprecated Global API Key to API Token 

### DIFF
--- a/docs/applications/cloudflare_ddns.md
+++ b/docs/applications/cloudflare_ddns.md
@@ -12,4 +12,6 @@ Set `cloudflare_ddns_enabled: true` in your `inventories/<your_inventory>/nas.ym
 
 ## Specific Configuration
 
-Make sure you set your Cloudflare login, domain and API key details within your `inventories/<your_inventory>/nas.yml` file.
+Make sure you set your domain (if different than the ansible-nas default) and access token details within your `inventories/<your_inventory>/nas.yml` file. If you need to create an API token, see https://joshuaavalon.github.io/docker-cloudflare/guide/cloudflare.html#authentication for instructions.
+
+Cloudflare has deprecated global API key authentication. If you have an older ansible-nas configuration using a global API key, you can upgrade to the API token-based authentication by removing the `cloudflare_api_key` variable from your local `nas.yml` configuration file and setting the `cloudflare_token` variable appropriately.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -300,6 +300,8 @@ cloudflare_host: "*.{{ cloudflare_zone }}"
 cloudflare_token: ""
 
 # Set to true to make traffic go through the CloudFlare CDN.
+# Note that if the cloudflare host is a wildcard (the default), this must be false, as cloudflare
+# does not support http proxy of wildcard CNAMEs.
 cloudflare_proxy: false
 
 # Set to AAAA to use set IPv6 records instead of IPv4 records.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -286,18 +286,17 @@ nfs_exports:
 ###
 # Cloudflare is a great free DNS option for domains. If you use the cloudflare_ddns container then you'll need to
 # set the options below.
-
+# Data directory for config file
+cloudflare_data_directory: "{{ docker_home }}/cloudflare_ddns"
 # Your domain name
 cloudflare_zone: "{{ ansible_nas_domain }}"
 
 # The hostname you want the container to update. You shouldn't need to change this.
 cloudflare_host: "*.{{ cloudflare_zone }}"
 
-# Email address used to register for Cloudflare
-cloudflare_email: "{{ ansible_nas_email }}"
-
-# Cloudflare 'Global API Key', can be found on the 'My Profile' page
-cloudflare_api_key: abcdeabcdeabcdeabcde1234512345
+# Cloudflare scoped token (https://joshuaavalon.github.io/docker-cloudflare/guide/cloudflare.html#authentication)
+# Make sure token permissions include #DNS:Edit and #Zone:Read
+cloudflare_token: ""
 
 ###
 ### General

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -288,6 +288,7 @@ nfs_exports:
 # set the options below.
 # Data directory for config file
 cloudflare_data_directory: "{{ docker_home }}/cloudflare_ddns"
+
 # Your domain name
 cloudflare_zone: "{{ ansible_nas_domain }}"
 
@@ -297,6 +298,12 @@ cloudflare_host: "*.{{ cloudflare_zone }}"
 # Cloudflare scoped token (https://joshuaavalon.github.io/docker-cloudflare/guide/cloudflare.html#authentication)
 # Make sure token permissions include #DNS:Edit and #Zone:Read
 cloudflare_token: ""
+
+# Set to true to make traffic go through the CloudFlare CDN.
+cloudflare_proxy: false
+
+# Set to AAAA to use set IPv6 records instead of IPv4 records.
+cloudflare_type: "A"
 
 ###
 ### General

--- a/tasks/cloudflare_ddns.yml
+++ b/tasks/cloudflare_ddns.yml
@@ -24,7 +24,7 @@
     image: joshava/cloudflare-ddns:latest
     pull: true
     volumes:
-      - "{{cloudflare_data_directory}}/config.yaml:/app/config.yaml"
+      - "{{ cloudflare_data_directory }}/config.yaml:/app/config.yaml"
     restart_policy: unless-stopped
     memory: 512MB
     recreate: "{{ template_files_result is changed or template_files_result_api is changed }}"

--- a/tasks/cloudflare_ddns.yml
+++ b/tasks/cloudflare_ddns.yml
@@ -1,14 +1,30 @@
+- name: Cloudflare Dynamic DNS  Directories
+  file:
+    path: "{{ cloudflare_data_directory }}"
+    state: directory
+  when: cloudflare_api_key is not defined
+
+- name: Template Cloudflare Dynamic DNS config.yaml with scoped token
+  template:
+    src: cloudflare-ddns/config.yaml
+    dest: "{{ cloudflare_data_directory }}/config.yaml"
+  register: template_files_result
+  when: cloudflare_api_key is not defined
+
+- name: Template Cloudflare Dynamic DNS  config.yaml with api_key (DEPRECATED)
+  template:
+    src: cloudflare-ddns/config-api.yaml
+    dest: "{{ cloudflare_data_directory }}/config.yaml"
+  register: template_files_result_api
+  when: cloudflare_api_key is defined
+
 - name: Cloudflare Dynamic DNS Container
   docker_container:
     name: cloudflare-ddns
     image: joshava/cloudflare-ddns:latest
     pull: true
-    env:
-      ZONE: "{{ cloudflare_zone }}"
-      HOST: "{{ cloudflare_host }}"
-      EMAIL: "{{ cloudflare_email }}"
-      API: "{{ cloudflare_api_key }}"
-      PROXY: "false"
+    volumes:
+      - "{{cloudflare_data_directory}}/config.yaml:/app/config.yaml"
     restart_policy: unless-stopped
     memory: 512MB
-
+    recreate: "{{ template_files_result is changed or template_files_result_api is changed }}"

--- a/templates/cloudflare-ddns/config-api.yaml
+++ b/templates/cloudflare-ddns/config-api.yaml
@@ -1,0 +1,9 @@
+auth:
+  globalToken: "{{ cloudflare_api_key }}"
+  email: "{{ cloudflare_email }}"
+domains:
+  - name: "{{ cloudflare_host }}"
+    type: A
+    proxied: false
+    create: true
+    zoneName: "{{ cloudflare_zone }}"

--- a/templates/cloudflare-ddns/config-api.yaml
+++ b/templates/cloudflare-ddns/config-api.yaml
@@ -3,7 +3,7 @@ auth:
   email: "{{ cloudflare_email }}"
 domains:
   - name: "{{ cloudflare_host }}"
-    type: A
-    proxied: false
+    type: "{{ cloudflare_type }}"
+    proxied: {{ cloudflare_proxy | bool }}
     create: true
     zoneName: "{{ cloudflare_zone }}"

--- a/templates/cloudflare-ddns/config.yaml
+++ b/templates/cloudflare-ddns/config.yaml
@@ -1,0 +1,8 @@
+auth:
+  scopedToken: "{{ cloudflare_token }}"
+domains:
+  - name: "{{ cloudflare_host }}"
+    type: A
+    proxied: false
+    create: true
+    zoneName: "{{ cloudflare_zone }}"

--- a/templates/cloudflare-ddns/config.yaml
+++ b/templates/cloudflare-ddns/config.yaml
@@ -2,7 +2,7 @@ auth:
   scopedToken: "{{ cloudflare_token }}"
 domains:
   - name: "{{ cloudflare_host }}"
-    type: A
-    proxied: false
+    type: "{{ cloudflare_type }}"
+    proxied: {{ cloudflare_proxy | bool }}
     create: true
     zoneName: "{{ cloudflare_zone }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

This PR fixes #243 for current configurations. Somehow, for me, even the latest joshava/cloudflare-ddns image with support for the latest Cloudflare API was not working for me. The author of that docker image has deprecated configuration by environment variables, so I refactored the ansible task to use a config file.

As Cloudflare has deprecated global API key access, I also updated the ansible-nas default to use the API Token authentication. To use API Token auth, existing users need to set the appropriate variable and remove the `cloudflare_api_key` variable. However, existing users need not change their configuration at all, so long as Cloudflare supports the global API key. 

**Which issue (if any) this PR fixes**:

Fixes #243 

**Any other useful info**:

I have tested this both with my old configuration (using global API key) and with a new access token. I believe this PR should be a straightforward fix for #243 (along with, obviously, the fact that the docker image was updated) and should allow ansible-nas users to move on from the deprecated global API key to the more granular and secure API Tokens.