### PR TITLE
Nextcloud MySQL credentials changed to variable for the security paranoid.

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -107,7 +107,7 @@ pytivo_enabled: false
 serposcope_enabled: false
 
 # External Access
-# Traefik will allow access to certain applications externally. To enable this you'll either; a domain name that points to your 
+# Traefik will allow access to certain applications externally. To enable this you'll either; a domain name that points to your
 # home static IP address, the cloudflare with the cloudflare_ddns dynamic DNS container enabled, or use a dynamic DNS provider like no-ip.
 # You'll also need to map ports 80 and 443 from your router to your ansible-nas server, then enable the per-app "available_externally"
 # settings.
@@ -567,7 +567,7 @@ couchpotato_downloads_directory: "{{ downloads_root }}"
 couchpotato_torrents_directory: "{{ torrents_root }}"
 couchpotato_user_id: "0"
 couchpotato_group_id: "0"
-couchpotato_port: "5050" 
+couchpotato_port: "5050"
 
 ###
 ### Sickchill
@@ -659,6 +659,9 @@ glances_port_two: "61209"
 nextcloud_available_externally: "false"
 nextcloud_data_directory: "{{ docker_home }}/nextcloud"
 nextcloud_port: "8080"
+nextcloud_sql_user: "nextcloud_sql_user"
+nextcloud_sql_pass: "nextcloud_sql_pass"
+nextcloud_sql_secret: "nextcloud_sql_secret"
 
 ###
 ### nginx

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -659,9 +659,9 @@ glances_port_two: "61209"
 nextcloud_available_externally: "false"
 nextcloud_data_directory: "{{ docker_home }}/nextcloud"
 nextcloud_port: "8080"
-nextcloud_sql_user: "nextcloud_sql_user"
-nextcloud_sql_pass: "nextcloud_sql_pass"
-nextcloud_sql_secret: "nextcloud_sql_secret"
+nextcloud_sql_user: "nextcloud-user"
+nextcloud_sql_pass: "nextcloud-pass"
+nextcloud_sql_secret: "nextcloud-secret"
 
 ###
 ### nginx

--- a/tasks/nextcloud.yml
+++ b/tasks/nextcloud.yml
@@ -16,9 +16,9 @@
       - "{{ nextcloud_data_directory }}/mysql:/var/lib/mysql:rw"
     env:
       MYSQL_DATABASE: "nextcloud"
-      MYSQL_USER: "nextcloud-user"
-      MYSQL_PASSWORD: "nextcloud-pass"
-      MYSQL_ROOT_PASSWORD: "nextcloud-secret"
+      MYSQL_USER: "{{ nextcloud_sql_user }}"
+      MYSQL_PASSWORD: "{{ nextcloud_sql_pass }}"
+      MYSQL_ROOT_PASSWORD: "{{ nextcloud_sql_secret }}"
     restart_policy: unless-stopped
     memory: 1g
 
@@ -36,8 +36,8 @@
     env:
       MYSQL_HOST: "mysql"
       MYSQL_DATABASE: "nextcloud"
-      MYSQL_USER: "nextcloud-user"
-      MYSQL_PASSWORD: "nextcloud-pass"
+      MYSQL_USER: "{{ nextcloud_sql_user }}"
+      MYSQL_PASSWORD: "{{ nextcloud_sql_pass }}"
       NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud.{{ ansible_nas_domain }}"
     restart_policy: unless-stopped
     memory: 1g


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Very small pull request to change the MySQL creds from a static string to variable that can be overridden by the user if desired. Whilst a minor security change, something I've been doing when exposing my Nextcloud instances to the internet as a potential damage limitation piece.

Default behavior remains as before, only affects implementation if overridden by the user. 

**Which issue (if any) this PR fixes**:
None.

Fixes #

**Any other useful info**:
