### PR TITLE
nextcloud: make mysql passwords customizable

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -658,6 +658,8 @@ glances_port_two: "61209"
 ###
 nextcloud_available_externally: "false"
 nextcloud_data_directory: "{{ docker_home }}/nextcloud"
+nextcloud_mysql_password: "nextcloud-pass"
+nextcloud_mysql_root_password: "nextcloud-secret"
 nextcloud_port: "8080"
 
 ###

--- a/tasks/nextcloud.yml
+++ b/tasks/nextcloud.yml
@@ -17,8 +17,8 @@
     env:
       MYSQL_DATABASE: "nextcloud"
       MYSQL_USER: "nextcloud-user"
-      MYSQL_PASSWORD: "nextcloud-pass"
-      MYSQL_ROOT_PASSWORD: "nextcloud-secret"
+      MYSQL_PASSWORD: "{{ nextcloud_mysql_password }}"
+      MYSQL_ROOT_PASSWORD: "{{ nextcloud_mysql_root_password }}"
     restart_policy: unless-stopped
     memory: 1g
 
@@ -37,7 +37,7 @@
       MYSQL_HOST: "mysql"
       MYSQL_DATABASE: "nextcloud"
       MYSQL_USER: "nextcloud-user"
-      MYSQL_PASSWORD: "nextcloud-pass"
+      MYSQL_PASSWORD: "{{ nextcloud_mysql_password }}"
       NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud.{{ ansible_nas_domain }}"
     restart_policy: unless-stopped
     memory: 1g


### PR DESCRIPTION
**What this PR does / why we need it**:
Making mysql passwords customizable would increase security. Additionally we can now use ansible-vault to encrypt the passwords.

Example for encrypted password in nas.yml:

```yaml
nextcloud_mysql_password: !vault |
  $ANSIBLE_VAULT;1.2;AES256;gate
  4389637678934528931363932373632306439313532323137316138[...]
```

I hope this PR is suitable and may help to improve this awesome project.

Cheers!