### PR TITLE
Plex: Enable some advanced features of docker container, including hardware transcode

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -436,6 +436,10 @@ plex_music_permissions: "rw"
 plex_user_id: "0"
 plex_group_id: "0"
 plex_port: "32400"
+plex_version: "docker"
+# Device mappings for the docker container.
+# E.g. To enable hardware transcoding:
+# plex_devices: [ "/dev/dri:/dev/dri" ]
 
 ###
 ### PyTivo

--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -25,6 +25,7 @@
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ plex_user_id }}"
       PGID: "{{ plex_group_id }}"
+      VERSION: "{{ plex_version }}"
     restart_policy: unless-stopped
     memory: 2g
     labels:
@@ -32,3 +33,33 @@
       traefik.frontend.rule: "Host:plex.{{ ansible_nas_domain }}"
       traefik.enable: "{{ plex_available_externally }}"
       traefik.port: "32400"
+  when: plex_devices is not defined
+
+- name: plex Docker Container with devices
+  docker_container:
+    name: plex
+    image: linuxserver/plex
+    pull: true
+    volumes:
+      - "{{ plex_config_directory }}:/config:rw"
+      - "{{ plex_logs }}:/opt/plex/Library/Application Support/Plex Media Server/Logs:rw"
+      - "{{ plex_movies_directory }}:/movies:{{ plex_movies_permissions }}"
+      - "{{ plex_tv_directory }}:/tv:{{ plex_tv_permissions }}"
+      - "{{ plex_photos_directory }}:/photos:{{ plex_photos_permissions }}"
+      - "{{ plex_podcasts_directory }}:/podcasts:{{ plex_podcasts_permissions }}"
+      - "{{ plex_music_directory }}:/music:{{ plex_music_permissions }}"
+    devices: "{{ plex_devices }}"
+    network_mode: "host"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ plex_user_id }}"
+      PGID: "{{ plex_group_id }}"
+      VERSION: "{{ plex_version }}"
+    restart_policy: unless-stopped
+    memory: 2g
+    labels:
+      traefik.backend: "plex"
+      traefik.frontend.rule: "Host:plex.{{ ansible_nas_domain }}"
+      traefik.enable: "{{ plex_available_externally }}"
+      traefik.port: "32400"
+  when: plex_devices is defined 

--- a/tasks/plex.yml
+++ b/tasks/plex.yml
@@ -62,4 +62,4 @@
       traefik.frontend.rule: "Host:plex.{{ ansible_nas_domain }}"
       traefik.enable: "{{ plex_available_externally }}"
       traefik.port: "32400"
-  when: plex_devices is defined 
+  when: plex_devices is defined


### PR DESCRIPTION
**What this PR does / why we need it**:

There are features of the Plex docker container that at present are not accessible from ansible-nas. Notably, I wanted to enable hardware transcode, which requires mapping a device into the docker container (as described in the [container docs](https://hub.docker.com/r/linuxserver/plex)).

The change here is minor: it allows a device mapping variable to be set, which can be used to enable hardware transcoding and dab support. In addition, a "plex_version" is used to allow easier upgrades, another feature of the container. The default setting in all.yml keeps the current behavior.

With this PR, others can easily enable hardware transcoding, dab support, or beta-channel updates by updating their config variables. If folks do not modify their configs, this PR does not change anything.

**Which issue (if any) this PR fixes**:

**Any other useful info**:
