### PR TITLE
More consistent use of variables in Samba share paths

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -251,7 +251,7 @@ samba_shares:
     public: yes
     writable: yes
     browsable: yes
-    path: "{{ samba_shares_root }}/photos"
+    path: "{{ photos_root }}"
 
   - name: books
     comment: 'Books'
@@ -259,7 +259,7 @@ samba_shares:
     public: yes
     writable: yes
     browsable: yes
-    path: "{{ samba_shares_root }}/books"
+    path: "{{ books_root }}"
 
   - name: comics
     comment: 'Comics'
@@ -267,7 +267,7 @@ samba_shares:
     public: yes
     writable: yes
     browsable: yes
-    path: "{{ samba_shares_root }}/comics"
+    path: "{{ comics_root }}"
 
 ###
 ### NFS


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

Updates the template all.yml file to use existing path variables instead of redefining the paths.