### PR TITLE
creating the .incomplete folder for utorrent

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -392,6 +392,7 @@ openvpn_config: United-Kingdom
 utorrent_available_externally: "false"
 utorrent_config_directory: "{{ docker_home }}/utorrent/config"
 utorrent_download_directory: "{{ downloads_root }}"
+utorrent_download_directory_active: "{{ downloads_root }}/.incomplete"
 utorrent_port_http: "8111"
 utorrent_port_bt: "6881"
 utorrent_user_id: "0"

--- a/tasks/utorrent.yml
+++ b/tasks/utorrent.yml
@@ -6,6 +6,7 @@
   with_items:
     - "{{ utorrent_config_directory }}"
     - "{{ utorrent_download_directory }}"
+    - "{{ utorrent_download_directory_active }}"
 
 - name: uTorrent Docker Container
   docker_container:


### PR DESCRIPTION
**What this PR does / why we need it**:
To address the '.incomplete/' non-exist issue which causing utorrent's download speed to be 0kb/s


**Which issue (if any) this PR fixes**:

Fixes #373

**Any other useful info**:
The fix just creates a default `.incomplete/` under the `downloads/` that's been mapped to utorrent `/data` Volume by default.