### PR TITLE
add deluge (re-upload of #380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Ansible config and a bunch of Docker containers.
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies
+* [Deluge](https://dev.deluge-torrent.org/) - A lightweight, Free Software, cross-platform BitTorrent client.
 * [Duplicati](https://www.duplicati.com/) - for backing up your stuff
 * [Emby](https://emby.media/) - Media streaming and management
 * [Firefly III](https://firefly-iii.org/) - Free and open source personal finance manager

--- a/docs/applications/deluge.md
+++ b/docs/applications/deluge.md
@@ -1,0 +1,18 @@
+# Deluge
+
+[Deluge](http://deluge-torrent.org/) is a lightweight, Free Software, cross-platform BitTorrent client.
+<img align="right" width="200" height="200" src="https://avatars2.githubusercontent.com/u/6733935?v=3&s=200">
+* Full Encryption
+* WebUI
+* Plugin System
+* Much more...
+
+## Usage
+
+Set `deluge_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+Deluge's web interface can be found at http://ansible_nas_host_or_ip:8112
+
+Upon first viewing you will be prompted for a password. The default is `deluge` It is recommended that you change this password in the preferences menu.
+
+**For more info visit: [https://dev.deluge-torrent.org/] & [https://github.com/linuxserver/docker-deluge/blob/master/README.md]

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -12,6 +12,7 @@ By default, applications can be found on the ports listed below.
 | Cloud Commander | 7373   |              |
 | Couchpotato     | 5050   |              |
 | Duplicati       | 8200   |              |
+| Deluge          | 8112   | HTTP         |
 | Emby            | 8096   | HTTP         |
 | Emby            | 8920   | HTTPS        |
 | Firefly III     | 8066   |              |

--- a/nas.yml
+++ b/nas.yml
@@ -68,6 +68,11 @@
         - couchpotato
       when: (couchpotato_enabled | default(False))
 
+    - role: deluge
+      tags:
+        - deluge
+      when: (deluge_enabled | default(False))
+
     - role: duplicati
       tags:
         - duplicati

--- a/roles/deluge/defaults/main.yml
+++ b/roles/deluge/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+deluge_enabled: false
+deluge_available_externally: "false"
+
+# directories
+deluge_config_directory: "{{ docker_home }}/deluge/config"
+deluge_download_directory: "{{ downloads_root }}"
+deluge_watch_directory: "{{ torrents_root }}"
+
+# uid / gid
+deluge_user_id: "0"
+deluge_group_id: "0"
+
+# error logging
+deluge_log_level: "error"
+
+# network
+deluge_port: "8112"
+deluge_hostname: "deluge"
+
+deluge_timezone: "{{ ansible_nas_timezone }}"

--- a/roles/deluge/tasks/main.yml
+++ b/roles/deluge/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Create Deluge Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    # mode: 0755
+  with_items:
+    - "{{ deluge_config_directory }}"
+    - "{{ deluge_download_directory }}"
+
+- name: Deluge Docker Container
+  docker_container:
+    name: deluge
+    image: linuxserver/deluge
+    pull: true
+    volumes:
+      - "{{ deluge_config_directory }}:/config:rw"
+      - "{{ deluge_download_directory }}:/root/Downloads:rw"
+    ports:
+      - "{{ deluge_port }}:8112"
+    env:
+      TZ: "{{ deluge_timezone }}"
+      PUID: "{{ deluge_user_id }}"
+      PGID: "{{ deluge_group_id }}"
+    restart_policy: unless-stopped
+    memory: 1g
+    labels:
+      traefik.enable: "{{ deluge_available_externally }}"
+      traefik.http.routers.deluge.rule: "Host(`{{ deluge_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.deluge.tls.certresolver: "letsencrypt"
+      traefik.http.routers.deluge.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.deluge.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.deluge.loadbalancer.server.port: "8112"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Adds Deluge bit torrent web client. 

**Which issue (if any) this PR fixes**:

Fixes #380 issues I made by not creating a separate branch on my fork.

**Any other useful info**:
I set deluge's downloads volume to be mounted at /root/downloads instead of /downloads because the default config of the client have the downloads folder pointed to that directory.