### PR TITLE
add ddns_updater application

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Ansible config and a bunch of Docker containers.
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies
+* [DDNS Updater](https://github.com/qdm12/ddns-updater) - dynamic dns updater for serveral providers
 * [Deluge](https://dev.deluge-torrent.org/) - A lightweight, Free Software, cross-platform BitTorrent client.
 * [Duplicati](https://www.duplicati.com/) - for backing up your stuff
 * [Emby](https://emby.media/) - Media streaming and management

--- a/docs/applications/ddns_updater.md
+++ b/docs/applications/ddns_updater.md
@@ -39,8 +39,7 @@ Set `ddns_updater_enabled: true` in your `inventories/<your_inventory>/nas.yml` 
 
 You have to define `ddns_updater_config` with the configuration of your provider(s).
 See https://github.com/qdm12/ddns-updater#configuration for configuration options.
-For an example on how to convert the configuration in json Format to the yaml/dict in  `ddns_updater_config`  see the
-role defaults.
+For an example on how to write the configuration in `ddns_updater_config` see the role defaults.
 
 Optionally, `ddns_updater_gotify_token` can be set to a gotify token in order to be notified about changes made to your
 dns.

--- a/docs/applications/ddns_updater.md
+++ b/docs/applications/ddns_updater.md
@@ -1,0 +1,46 @@
+# Dynamic DNS Updater
+
+Lightweight universal DDNS Updater with Docker and web UI
+
+Homepage: [https://github.com/qdm12/ddns-updater](https://github.com/qdm12/ddns-updater)
+
+Light container updating DNS A and/or AAAA records periodically for multiple DNS providers.
+
+Currently supported providers:
+* Cloudflare
+* DDNSS.de
+* DigitalOcean
+* DonDominio
+* DNSOMatic
+* DNSPod
+* Dreamhost
+* DuckDNS
+* DynDNS
+* FreeDNS
+* Gandi
+* GoDaddy
+* Google
+* He.net
+* Infomaniak
+* Linode
+* LuaDNS
+* Namecheap
+* NoIP
+* OpenDNS
+* OVH
+* Selfhost.de
+* Strato.de
+
+## Usage
+
+Set `ddns_updater_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+## Specific Configuration
+
+You have to define `ddns_updater_config` with the configuration of your provider(s).
+See https://github.com/qdm12/ddns-updater#configuration for configuration options.
+For an example on how to convert the configuration in json Format to the yaml/dict in  `ddns_updater_config`  see the
+role defaults.
+
+Optionally, `ddns_updater_gotify_token` can be set to a gotify token in order to be notified about changes made to your
+dns.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -11,6 +11,7 @@ By default, applications can be found on the ports listed below.
 | Calibre-web     | 8084    | Bridge  | HTTP           |
 | Cloud Commander | 7373    | Bridge  | HTTP           |
 | Couchpotato     | 5050    | Bridge  | HTTP           |
+| ddns-updater    | 8202    | Bridge  | HTTP           |
 | Duplicati       | 8200    | Bridge  | HTTP           |
 | Emby            | 8096    | Bridge  | HTTP           |
 | Emby            | 8096    | Bridge  | HTTP           |

--- a/nas.yml
+++ b/nas.yml
@@ -73,6 +73,11 @@
         - couchpotato
       when: (couchpotato_enabled | default(False))
 
+    - role: ddns_updater
+      tags:
+        - ddns_updater
+      when: (ddns_updater_enabled | default(False))
+
     - role: deluge
       tags:
         - deluge

--- a/roles/ddns_updater/defaults/main.yml
+++ b/roles/ddns_updater/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# enable the role
+ddns_updater_enabled: false
+
+# Data directory for config file
+ddns_updater_data_directory: "{{ docker_home }}/ddns_updater"
+
+# enable in order to make web ui reachable from external
+ddns_updater_available_externally: "false"
+
+# Port for the web ui
+ddns_updater_port: 8202
+ddns_updater_hostname: "ddns"
+
+# User to run the container with
+ddns_updater_user_id: "0"
+
+# Token to be used to send messages via gotify
+# ddns_updater_gotify_token: "ABCDEFGHIJKLMOP"
+
+# url of gotify server
+gotify_url: "gotify.{{ ansible_nas_domain }}"
+
+# dict to pass in additional environment variables
+# available in the docker images (https://github.com/qdm12/ddns-updater#environment-variables)
+ddns_update_extra_env: {}
+
+# ddns_updater_config describes the content of the config.json
+# used to configure the updater
+# see https://github.com/qdm12/ddns-updater#configuration
+#
+# using cloudflare should work with a config like this:
+#
+#ddns_updater_config:
+#  settings:
+#    - provider: "cloudflare"
+#      zone_identifier: "{{ cloudflare_zone }}",
+#      domain: "{{ cloudflare_host }}"
+#      host: "@"
+#      ttl: 1
+#      token: "{{ cloudflare_token }}"
+#      proxied: { { cloudflare_proxy | bool } }

--- a/roles/ddns_updater/defaults/main.yml
+++ b/roles/ddns_updater/defaults/main.yml
@@ -2,6 +2,9 @@
 # enable the role
 ddns_updater_enabled: false
 
+# docker image used
+ddns_updater_docker_image:  qmcgaw/ddns-updater:latest
+
 # Data directory for config file
 ddns_updater_data_directory: "{{ docker_home }}/ddns_updater"
 

--- a/roles/ddns_updater/defaults/main.yml
+++ b/roles/ddns_updater/defaults/main.yml
@@ -1,32 +1,39 @@
 ---
-# enable the role
+# Enable the role
 ddns_updater_enabled: false
 
-# docker image used
+# Docker image used
 ddns_updater_docker_image:  qmcgaw/ddns-updater:latest
 
 # Data directory for config file
 ddns_updater_data_directory: "{{ docker_home }}/ddns_updater"
 
-# enable in order to make web ui reachable from external
+# Enable in order to make web ui reachable from external
 ddns_updater_available_externally: "false"
 
 # Port for the web ui
 ddns_updater_port: 8202
+
+# Hostname for subdomain
 ddns_updater_hostname: "ddns"
 
 # User to run the container with
 ddns_updater_user_id: "0"
 
 # Token to be used to send messages via gotify
-# ddns_updater_gotify_token: "ABCDEFGHIJKLMOP"
+ddns_updater_gotify_token: "token"
 
-# url of gotify server
-gotify_url: "gotify.{{ ansible_nas_domain }}"
+# Url of gotify server
+gotify_url: "https://gotify.{{ ansible_nas_domain }}"
 
-# dict to pass in additional environment variables
-# available in the docker images (https://github.com/qdm12/ddns-updater#environment-variables)
-ddns_updater_extra_env: {}
+# Period of IP address check
+ddns_updater_period: 5m
+
+# Duration to cooldown between updates for each record. This is useful to avoid being rate limited or banned.
+ddns_updater_cooldown_period: 5m
+
+# Timeout for all HTTP requests
+ddns_updater_http_timeout: 10s
 
 # ddns_updater_config describes the content of the config.json
 # used to configure the updater
@@ -34,12 +41,17 @@ ddns_updater_extra_env: {}
 #
 # using cloudflare should work with a config like this:
 #
-#ddns_updater_config:
-#  settings:
-#    - provider: "cloudflare"
-#      zone_identifier: "{{ cloudflare_zone }}",
-#      domain: "{{ cloudflare_host }}"
-#      host: "@"
-#      ttl: 1
-#      token: "{{ cloudflare_token }}"
-#      proxied: { { cloudflare_proxy | bool } }
+# ddns_updater_config: >
+#   {
+#     "settings": [
+#       {
+#         "provider": "cloudflare",
+#         "zone_identifier": "some id",
+#         "domain": "domain.com",
+#         "host": "@",
+#         "ttl": 600,
+#         "token": "yourtoken",
+#         "ip_version": "ipv4"
+#       }
+#     ]
+#   }

--- a/roles/ddns_updater/defaults/main.yml
+++ b/roles/ddns_updater/defaults/main.yml
@@ -3,7 +3,7 @@
 ddns_updater_enabled: false
 
 # Docker image used
-ddns_updater_docker_image:  qmcgaw/ddns-updater:latest
+ddns_updater_docker_image: qmcgaw/ddns-updater:latest
 
 # Data directory for config file
 ddns_updater_data_directory: "{{ docker_home }}/ddns_updater"

--- a/roles/ddns_updater/defaults/main.yml
+++ b/roles/ddns_updater/defaults/main.yml
@@ -26,7 +26,7 @@ gotify_url: "gotify.{{ ansible_nas_domain }}"
 
 # dict to pass in additional environment variables
 # available in the docker images (https://github.com/qdm12/ddns-updater#environment-variables)
-ddns_update_extra_env: {}
+ddns_updater_extra_env: {}
 
 # ddns_updater_config describes the content of the config.json
 # used to configure the updater

--- a/roles/ddns_updater/tasks/main.yml
+++ b/roles/ddns_updater/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: Dynamic DNS Container
   docker_container:
     name: ddns-updater
-    image: qmcgaw/ddns-updater:latest
+    image: "{{ ddns_updater_docker_image }}"
     pull: true
     ports:
       - "{{ ddns_updater_port }}:8000"

--- a/roles/ddns_updater/tasks/main.yml
+++ b/roles/ddns_updater/tasks/main.yml
@@ -10,20 +10,8 @@
 
 - name: Generate config.json
   copy:
-    content: "{{ ddns_updater_config | to_nice_json }}"
+    content: "{{ ddns_updater_config | from_json | to_nice_json }}"
     dest: "{{ ddns_updater_data_directory }}/config.json"
-
-- name: Generate dns docker environment
-  set_fact:
-    ddns_update_env: |
-      TZ: "{{ ansible_nas_timezone }}"
-      {% if ddns_updater_gotify_token is defined %}
-      GOTIFY_TOKEN: {{ ddns_updater_gotify_token }}
-      GOTIFY_URL: {{ gotify_url }}
-      {% endif %}
-      {% for env in ddns_updater_extra_env|dict2items %}
-      {{ env.key }}: {{ env.value }}
-      {% endfor %}
 
 - name: Dynamic DNS Container
   docker_container:
@@ -34,7 +22,13 @@
       - "{{ ddns_updater_port }}:8000"
     volumes:
       - "{{ ddns_updater_data_directory }}:/updater/data:rw"
-    env: "{{ ddns_update_env | from_yaml }}"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      GOTIFY_TOKEN: "{{ ddns_updater_gotify_token }}"
+      GOTIFY_URL: "{{ gotify_url }}"
+      PERIOD: "{{ ddns_updater_period }}"
+      UPDATE_COOLDOWN_PERIOD: "{{ ddns_updater_cooldown_period }}"
+      HTTP_TIMEOUT: "{{ ddns_updater_http_timeout }}"
     restart_policy: unless-stopped
     user: "{{ ddns_updater_user_id }}"
     labels:

--- a/roles/ddns_updater/tasks/main.yml
+++ b/roles/ddns_updater/tasks/main.yml
@@ -21,7 +21,7 @@
       GOTIFY_TOKEN: {{ ddns_updater_gotify_token }}
       GOTIFY_URL: {{ gotify_url }}
       {% endif %}
-      {% for env in ddns_update_extra_env|dict2items %}
+      {% for env in ddns_updater_extra_env|dict2items %}
       {{ env.key }}: {{ env.value }}
       {% endfor %}
 

--- a/roles/ddns_updater/tasks/main.yml
+++ b/roles/ddns_updater/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: Create DDNS Updater Directories
+  file:
+    path: "{{ ddns_updater_data_directory }}"
+    state: directory
+
+- name: Check config is defined
+  fail: msg="No 'ddns_updater_config' defined."
+  when: ddns_updater_config is not defined
+
+- name: Generate config.json
+  copy:
+    content: "{{ ddns_updater_config | to_nice_json }}"
+    dest: "{{ ddns_updater_data_directory }}/config.json"
+
+- name: Generate dns docker environment
+  set_fact:
+    ddns_update_env: |
+      TZ: "{{ ansible_nas_timezone }}"
+      {% if ddns_updater_gotify_token is defined %}
+      GOTIFY_TOKEN: {{ ddns_updater_gotify_token }}
+      GOTIFY_URL: {{ gotify_url }}
+      {% endif %}
+      {% for env in ddns_update_extra_env|dict2items %}
+      {{ env.key }}: {{ env.value }}
+      {% endfor %}
+
+- name: Dynamic DNS Container
+  docker_container:
+    name: ddns-updater
+    image: qmcgaw/ddns-updater:latest
+    pull: true
+    ports:
+      - "{{ ddns_updater_port }}:8000"
+    volumes:
+      - "{{ ddns_updater_data_directory }}:/updater/data:rw"
+    env: "{{ ddns_update_env | from_yaml }}"
+    restart_policy: unless-stopped
+    user: "{{ ddns_updater_user_id }}"
+    labels:
+      traefik.enable: "{{ ddns_updater_available_externally }}"
+      traefik.http.routers.airsonic.rule: "Host(`{{ ddns_updater_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.airsonic.tls.certresolver: "letsencrypt"
+      traefik.http.routers.airsonic.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.airsonic.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.airsonic.loadbalancer.server.port: "8000"


### PR DESCRIPTION
**What this PR does / why we need it**:
I don't use cloudflare but a different provider, so I replaced cloudflare_ddns role with a ddns_updater role.
The role uses https://github.com/qdm12/ddns-updater which supports lots of providers and is easy to use. 
Of course it also supports cloudflare.

**Any other useful info**:
This PR is not complete, yet. The role is working, but I need some opinion on how to continue with this. Afterwards I can finish it up.
So here are things I'm not sure how I should implement it:
- Currently I just replaced cloudflare and the original variables are just dropped. Should there be an automatic migration? Should I write a template that generates a config based on the original cloudflare variables?
- I included an example how the config for cloudflare should look like. Since I have no cloudflare account I would be glad if someone could test that.