### PR TITLE
WIP: Enable Traefik forward authentication and dynamic file configuration

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -27,3 +27,23 @@ traefik_environment_variables:
 # the "{{ docker_home }}/traefik" after changing this setting.
 # traefik_acme_server: "https://acme-staging-v02.api.letsencrypt.org/directory" # staging
 traefik_acme_server: "https://acme-v02.api.letsencrypt.org/directory" # production
+
+# forwardauth using Google OAuth requries a client id and secret
+traefik_forwardauth_hostname: "auth"
+traefik_google_client_id: "28923428222-3jra876g8a7fg3h9ajf83jaf376hafa.apps.googleusercontent.com"
+traefik_google_client_secret: "f3a3-hH3JDe-ganlIUNAnffoe"
+
+# secret must be random: "openssl rand -hex 16"
+traefik_forwardauth_secret: "oh9dga4s8b653d86n854nusid6bnkljs"
+
+# Whitelist of account names to allow
+traefik_forwardauth_whitelist: ""
+
+traefik_forwardauth_environment_variables:
+  PROVIDERS_GOOGLE_CLIENT_ID: "{{ traefik_google_client_id }}"
+  PROVIDERS_GOOGLE_CLIENT_SECRET: "{{ traefik_google_client_secret }}"
+  SECRET: "{{ traefik_forwardauth_secret }}"
+  INSECURE_COOKIE: "true"
+  AUTH_HOST: "{{ traefik_forwardauth_hostname }}.{{ ansible_nas_domain }}"
+  COOKIE_DOMAIN: "{{ ansible_nas_domain }}"
+  WHITELIST: "{{ traefik_forwardauth_whitelist }}"

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -5,6 +5,7 @@
     state: directory
   with_items:
     - "{{ traefik_data_directory }}"
+    - "{{ traefik_data_directory }}/config"
     - "{{ traefik_data_directory }}/letsencrypt"
 
 - name: Template Traefik config.toml
@@ -12,6 +13,27 @@
     src: traefik.toml
     dest: "{{ traefik_data_directory }}/traefik.toml"
   register: template_config
+
+- name: Traefik ForwardAuth Container
+  docker_container:
+    name: traefik-forward-auth
+    image: thomseddon/traefik-forward-auth:2
+    env: "{{ traefik_forwardauth_environment_variables }}"
+    ports:
+      - "4181:4181"
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.auth.rule: "Host(`{{ traefik_forwardauth_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.auth.entrypoints: "websecure"
+      traefik.http.routers.auth.tls.certresolver: "letsencrypt"
+      traefik.http.routers.auth.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.auth.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.routers.auth.service: "traefik-forward-auth@docker"
+      traefik.http.middlewares.traefik-forward-auth.forwardauth.address: "http://localhost:4181"
+      traefik.http.middlewares.traefik-forward-auth.forwardauth.trustForwardHeader: "true"
+      traefik.http.middlewares.traefik-forward-auth.forwardauth.authResponseHeaders: "X-Forwarded-User"
+      traefik.http.services.traefik-forward-auth.loadbalancer.server.port: "4181"
+      traefik.http.routers.auth.middlewares: "traefik-forward-auth"
 
 - name: Traefik Docker Container
   docker_container:
@@ -22,6 +44,7 @@
     volumes:
       - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
       - "{{ traefik_data_directory }}/letsencrypt:/letsencrypt:rw"
+      - "{{ traefik_data_directory }}/config:/etc/traefik/config:ro"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     env: "{{ traefik_environment_variables }}"
     restart_policy: unless-stopped

--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -24,6 +24,8 @@
   providersThrottleDuration = "2s"
   [providers.docker]
     exposedbydefault = false
+  [providers.file]
+    directory = "/etc/traefik/config"
 
 [api]
   insecure = true
@@ -44,3 +46,4 @@
 
       [certificatesResolvers.letsencrypt.acme.dnsChallenge]
         provider = "{{ traefik_dns_provider }}"
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds forward authentication to Traefik to enable OAuth authentication for any ansible-nas integrated application proxied by traefik.

**Which issue (if any) this PR fixes**:

#425 

**Any other useful info**:

Right now this only adds functional authentication middleware to traefik, it doesn't enable authentication for any applications. Right now the best way I can think of to add authentication is the addition of a label and one boolean variable to every ansible task. You _can_ protect an entire traefik entrypoint without touching the individual tasks but there are good reasons not to OAuth every ansible-nas application.

Note: the client id, client secret, and cookie secret in this are examples and do not correspond to any real Google OAuth setup. 

This also includes an unnecessary change to enable file providers in traefik in case anyone wants to manually add some non-ansible application to their traefik setup by dropping some yaml/toml files into a host folder. 