### PR TITLE
Minor update of installation instructions for roles

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -27,7 +27,7 @@ You can run Ansible-NAS from the computer you plan to use for your NAS, or from 
 
     `cp -rfp inventories/sample inventories/my-ansible-nas`
 
-5. Review `group_vars/all.yml`. Change settings by overriding them in `inventories/my-ansible-nas/group_vars/nas.yml`.
+5. Review `group_vars/all.yml` for general settings and `roles/[application]/defaults/main.yml` for individual applications. Change settings by overriding them in `inventories/my-ansible-nas/group_vars/nas.yml`.
 
 6. Update `inventories/my-ansible-nas/inventory`.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Just a tiny change to the installation instructions to make it more obvious where to find settings for applications switched to roles.

**Which issue (if any) this PR fixes**:

This is just a band-aid on #400 that at least points new people in the right direction to find settings for all the role-migrated applications.

**Any other useful info**:

I'm sure there is plenty of other documentation changes that would be useful but this would probably save brand new people some hassle.