### PR TITLE
Make the watchtower_memory default an actual default

### DIFF
--- a/roles/watchtower/defaults/main.yml
+++ b/roles/watchtower/defaults/main.yml
@@ -17,4 +17,4 @@ watchtower_command: "--schedule '{{ watchtower_cron_schedule }}'"
 # watchtower_command: "--schedule '{{ watchtower_cron_schedule }}' --notifications 'slack' --notification-slack-hook-url 'https://hooks.slack.com/services/xxx/yyyyyyyyyyyyyyy' --notification-slack-identifier 'ansible-nas'"
 
 # specs
-memory: "{{ watchtower_memory }}"
+watchtower_memory: 1g


### PR DESCRIPTION
The watchtower_memory default was not set. Fixes https://github.com/davestephens/ansible-nas/issues/435