### PR TITLE
Grafana was not linked in traefik anymore

### DIFF
--- a/tasks/stats.yml
+++ b/tasks/stats.yml
@@ -114,4 +114,4 @@
       traefik.http.routers.grafana.tls.certresolver: "letsencrypt"
       traefik.http.routers.grafana.tls.domains[0].main: "{{ ansible_nas_domain }}"
       traefik.http.routers.grafana.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
-      traefik.http.grafana.netdata.loadbalancer.server.port: "3000"
+      traefik.http.services.grafana.loadbalancer.server.port: "3000"


### PR DESCRIPTION
This pull request fixes https://github.com/davestephens/ansible-nas/issues/437. Guess the stats should be migrated to a role as well, but didn't want to mix fixing a bug and changing from task to a role in the same commit.