### PR TITLE
fix mismatch in transmission-with-openvpn variable

### DIFF
--- a/roles/transmission-with-openvpn/tasks/main.yml
+++ b/roles/transmission-with-openvpn/tasks/main.yml
@@ -49,7 +49,7 @@
     restart_policy: unless-stopped
     memory: "{{ transmission_openvpn_memory }}"
     labels:
-      traefik.enable: "{{ transmission_openvpn_available_externally }}"
+      traefik.enable: "{{ transmission_with_openvpn_available_externally }}"
       traefik.http.routers.transmission_openvpn.rule: "Host(`{{ transmission_openvpn_hostname }}.{{ ansible_nas_domain }}`)"
       traefik.http.routers.transmission_openvpn.tls.certresolver: "letsencrypt"
       traefik.http.routers.transmission_openvpn.tls.domains[0].main: "{{ ansible_nas_domain }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix mismatch in transmission_with_openvpn variables. The "_with_" was omitted in `roles/transmission-with-openvpn/tasks/main.yml`

**Which issue (if any) this PR fixes**:

Fixes #431 

**Any other useful info**:

Error:

```
TASK [transmission-with-openvpn : Transmission with VPN] ****************************************************************************************************************************************
fatal: [192.168.1.xxx]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'transmission_openvpn_available_externally' is undefined\n\nThe error appears to be in '~/ansible-nas/roles/transmission-with-openvpn/tasks/main.yml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Transmission with VPN\n  ^ here\n"}
```
 (file paths and IP redacted out of an over abundance of caution)