### PR TITLE
move gitlab_user_id to defaults/main.yml

### DIFF
--- a/roles/gitlab/defaults/main.yml
+++ b/roles/gitlab/defaults/main.yml
@@ -6,6 +6,10 @@ gitlab_available_externally: "false"
 # directories
 gitlab_data_directory: "{{ docker_home }}/gitlab"
 
+# uid/gid
+gitlab_user_id: "998"
+gitlab_group_id: "{{ gitlab_user_id }}"
+
 # network
 gitlab_hostname: "gitlab"
 gitlab_port_http: "4080"

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -3,23 +3,13 @@
 - name: Create Gitlab group account
   group:
     name: gitlab
-    gid: 998
+    gid: "{{ gitlab_user_id }}"
     state: present
 
 - name: Create Gitlab user account
   user:
     name: gitlab
-    uid: 998
-    state: present
-    system: yes
-    update_password: on_create
-    create_home: no
-    group: gitlab
-
-- name: Create Gitlab user account
-  user:
-    name: gitlab
-    uid: 998
+    uid: "{{ gitlab_user_id }}"
     state: present
     system: yes
     update_password: on_create


### PR DESCRIPTION
**What this PR does / why we need it**:

Make `gitlab_user_id` configurable to allow working around conflicts.

**Any other useful info**:

Also removed duplicated Create Gitlab user account task