### PR TITLE
change jackett tag to just jackett

### DIFF
--- a/nas.yml
+++ b/nas.yml
@@ -250,7 +250,7 @@
 
     - role: transmission-with-openvpn
       tags:
-        - transmission_with_openvpn_enabled
+        - transmission_with_openvpn
       when: (transmission_with_openvpn_enabled | default(False))
 
     - role: utorrent

--- a/nas.yml
+++ b/nas.yml
@@ -135,7 +135,7 @@
 
     - role: jackett
       tags:
-        - jackettfalse
+        - jackett
       when: (jackett_enabled | default(False))
 
     - role: lidarr


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed tag names for roles change `transmission_with_openvpn` and `jackett`

**Which issue (if any) this PR fixes**:

Removed "false" from `jackett` tag so it is just "jackett". It was previously "jackettfalse", which looked like a typo.

Removed "_enabled" from `transmission_with_openvpn` tag for the same reason.


