### PR TITLE
change docker image for airsonic role

### DIFF
--- a/roles/airsonic/defaults/main.yml
+++ b/roles/airsonic/defaults/main.yml
@@ -7,6 +7,13 @@ airsonic_data_directory: "{{ docker_home }}/airsonic"
 airsonic_music_directory: "{{ music_root }}"
 airsonic_podcasts_directory: "{{ podcasts_root }}"
 
+# docker image
+airsonic_docker_image: linuxserver/airsonic
+
+# uid / gid
+airsonic_user_id: "0"
+airsonic_group_id: "0"
+
 # network
 airsonic_port: "4040"
 airsonic_hostname: "airsonic"

--- a/roles/airsonic/tasks/main.yml
+++ b/roles/airsonic/tasks/main.yml
@@ -11,15 +11,19 @@
 - name: Airsonic Docker Container
   docker_container:
     name: airsonic
-    image: airsonic/airsonic:latest
+    image: "{{ airsonic_docker_image }}"
     pull: true
     volumes:
-      - "{{ airsonic_data_directory }}/data:/airsonic/data:rw"
-      - "{{ airsonic_data_directory }}/playlists:/airsonic/playlists:rw"
-      - "{{ airsonic_music_directory }}:/airsonic/music:rw"
-      - "{{ airsonic_podcasts_directory }}:/airsonic/podcasts:rw"
+      - "{{ airsonic_data_directory }}/data:/config:rw"
+      - "{{ airsonic_data_directory }}/playlists:/playlists:rw"
+      - "{{ airsonic_music_directory }}:/music:rw"
+      - "{{ airsonic_podcasts_directory }}:/podcasts:rw"
     ports:
       - "{{ airsonic_port }}:4040"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ airsonic_user_id }}"
+      PGID: "{{ airsonic_group_id }}"
     restart_policy: unless-stopped
     memory: "{{ airsonic_memory }}"
     labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the airsonic docker image configurable.
Additionally, the default image is changed to https://hub.docker.com/r/linuxserver/airsonic because it also supports arm architectures.