### PR TITLE
Clear up confusion with 2 nas.ymls

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -33,4 +33,4 @@ You can run Ansible-NAS from the computer you plan to use for your NAS, or from 
 
 7. Install the dependent roles: `ansible-galaxy install -r requirements.yml` (you might need `sudo` to install Ansible roles).
 
-8. Run the playbook - something like `ansible-playbook -i inventories/my-ansible-nas/inventory nas.yml -b -K` should do you nicely.
+8. Run the playbook - something like `ansible-playbook -i inventories/my-ansible-nas/inventory nas.yml -b -K` should do you nicely. Ensure you are in the `~\ansible-nas\` directory, not `inventories/my-ansible-nas/group_vars/`, as there are two nas.yml files.


### PR DESCRIPTION
**What this PR does / why we need it**:
There are two files named nas.yml, one in `~/ansible-nas/` and one in ~/ansible-nas/inventories/my-ansible-nas/group-vars/`. This PR adds extra text to line 8 of the installation instructions to clear this up.
