### PR TITLE
Fix LE for Bitwarden-rs and also make the bitwarden domain configurable.

### DIFF
--- a/roles/bitwarden/defaults/main.yml
+++ b/roles/bitwarden/defaults/main.yml
@@ -4,6 +4,7 @@ bitwarden_available_externally: "false"
 bitwarden_data_directory: "{{ docker_home }}/bitwarden"
 bitwarden_port_a: "19080"
 bitwarden_port_b: "3012"
+bitwarden_hostname: "bitwarden"
 
 # Keep this token secret, this is password to access admin area of your server!
 # This token can be anything, but it's recommended to use a long, randomly generated string of characters,

--- a/roles/bitwarden/tasks/main.yml
+++ b/roles/bitwarden/tasks/main.yml
@@ -22,12 +22,15 @@
       LOG_FILE: "/data/bitwarden.log"
       WEBSOCKET_ENABLED: "true"
     labels:
-      traefik.web.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }}"
       traefik.enable: "{{ bitwarden_available_externally }}"
-      traefik.web.port: "80"
-      traefik.hub.frontend.rule: "Host:bitwarden.{{ ansible_nas_domain }};Path:/notifications/hub"
-      traefik.hub.port: "bitwarden_port_b"
-      traefik.hub.protocol: "ws"
+      traefik.http.routers.bitwarden-web.rule: "Host(`{{ bitwarden_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.bitwarden-web.tls.certresolver: "letsencrypt"
+      traefik.http.routers.bitwarden-web.service: "bitwarden-web"
+      traefik.http.services.bitwarden-web.loadbalancer.server.port: "80"
+      traefik.http.routers.bitwarden-hub.rule: "Host(`{{ bitwarden_hostname }}.{{ ansible_nas_domain }}`) && Path(`/notifications/hub`)"
+      traefik.http.routers.bitwarden-hub.tls.certresolver: "letsencrypt"
+      traefik.http.routers.bitwarden-hub.service: "bitwarden-hub"
+      traefik.http.services.bitwarden-hub.loadbalancer.server.port: "{{ bitwarden_port_b }}"
     memory: "{{ bitwarden_memory }}"
     restart_policy: unless-stopped
 

--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -11,11 +11,11 @@
       [entryPoints.websecure.http.tls]
         certResolver = "letsencrypt"
 
-        [entryPoints.websecure.http.tls.domains]
-          main = "{{ ansible_nas_domain }}"
-          sans = [
-            "*.{{ ansible_nas_domain }}"
-          ]
+        # [entryPoints.websecure.http.tls.domains]
+        #   main = "{{ ansible_nas_domain }}"
+        #   sans = [
+        #     "*.{{ ansible_nas_domain }}"
+        #   ]
 
   [entryPoints.traefik]
     address = ":{{ traefik_port_ui }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
LE was broken for bitwarden. It seemingly used an old way of configuring traefik and always failed to get the certificate.

**Which issue (if any) this PR fixes**:

**Any other useful info**:

I would highly advise to not grab wild card certificates. Traefik can manage many of them without issues.

Best,
Yatekii