### PR TITLE
add OpenNMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Ansible config and a bunch of Docker containers.
 * [Ombi](https://ombi.io/) - web application that automatically gives your users the ability to request content
 * [Organizr](https://organizr.app/) - ORGANIZR aims to be your one stop shop for your Servers Frontend.
 * [openHAB](https://www.openhab.org/) - A vendor and technology agnostic open source automation software for your home
+* [OpenNMS](https://www.opennms.com//) - an open source enterprise grade network management application platform.
 * [Plex](https://www.plex.tv/) - Plex Media Server
 * [Portainer](https://portainer.io/) - for managing Docker and running custom images
 * [pyLoad](https://pyload.net/) - A download manager with a friendly web-interface

--- a/docs/applications/opennms.md
+++ b/docs/applications/opennms.md
@@ -1,0 +1,23 @@
+# OpenNMS
+
+Homepage: [https://www.opennms.com//](https://www.opennms.com//)
+
+OpenNMS is an enterprise grade network management application platform developed under the open source model.
+
+Learn more in the [OpenNMS gituhub repo](https://github.com/OpenNMS/opennms) and [OpenNMS Administrators Guide](https://docs.opennms.org/opennms/releases/27.1.1/guide-admin/guide-admin.html)
+
+## Usage
+
+Set `opennms_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The default username and password is `admin`. Login to the Web User Interface and change the default admin password.
+
+## Ports
+
+The OpenNMS web interface is available at port 8980. OpenNMS also uses these ports:
+
+| Application          | Port    | Mode    | Notes          |
+|----------------------|---------|---------|----------------|
+| OpenNMS              | 8980    | Bridge  | HTTP           |
+| OpenNMS Karaf Shell  | 8101    | Bridge  | HTTP           |
+| OpenNMS ActiveMQ     | 61616   | Bridge  | HTTP           |

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -54,6 +54,9 @@ By default, applications can be found on the ports listed below.
 | Ombi            | 3579    | Bridge  | HTTP           |
 | openHAB         | 7777    | Host    | HTTP           |
 | openHAB         | 7778    | Host    | HTTPS          |
+| OpenNMS         | 8980    | Bridge  | HTTP           |
+| OpenNMS         | 8101    | Bridge  | HTTP           |
+| OpenNMS         | 61616   | Bridge  | HTTP           |
 | Organizr        | 10081   | Bridge  | HTTP           |
 | Organizr        | 10444   | Bridge  | HTTPS          |
 | Plex            | 32400   | Bridge  | HTTP           |

--- a/nas.yml
+++ b/nas.yml
@@ -208,6 +208,11 @@
         - ombi
       when: (ombi_enabled | default(False))
 
+    - role: opennms
+      tags:
+        - opennms
+      when: (opennms_enabled | default(False))
+
     - role: plex
       tags:
         - plex

--- a/roles/opennms/defaults/main.yml
+++ b/roles/opennms/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+opennms_enabled: false
+opennms_available_externally: "false"
+
+# directories
+opennms_data_directory: "{{ docker_home }}/opennms"
+
+# uid / gid
+opennms_user_id: "1000"
+opennms_group_id: "1000"
+
+# network
+opennms_port: "8980"
+opennms_port_karaf: "8101"
+opennms_port_activemq: "61616"
+opennms_hostname: "opennms"
+
+# username / passwords
+opennms_sql_user: "opennms-user"
+opennms_sql_password: "opennms-pass"
+opennms_db_name: "opennms"
+opennms_db_user: "opennms"
+opennms_db_pass: "opennms"
+
+# specs
+opennms_memory: 1g
+opennms_postgres_memory: 1g

--- a/roles/opennms/tasks/main.yml
+++ b/roles/opennms/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Create OpenNMS directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ opennms_data_directory }}/opennms"
+    - "{{ opennms_data_directory }}/postgres"
+
+- name: OpenNMS PostgreSQL Docker Container
+  docker_container:
+    name: opennms-database
+    image: postgres:12
+    pull: true
+    volumes:
+      - "{{ opennms_data_directory }}/postgres:/var/lib/postgresql/data:rw"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      POSTGRES_USER: "{{ opennms_sql_user }}"
+      POSTGRES_PASSWORD: "{{ opennms_sql_password }}"
+    restart_policy: unless-stopped
+    memory: "{{ opennms_postgres_memory }}"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 10s
+      timeout: 30s
+      retries: 3
+
+- name: OpenNMS Docker Container
+  docker_container:
+    name: opennms
+    image: opennms/horizon:release-27.x
+    pull: true
+    volumes:
+      - "{{ opennms_data_directory }}/opennms:/opt/opennms/share/rrd:rw"
+      - ./overlay:/opt/opennms-overlay
+    command: ["-s"]
+    links:
+      - opennms-database:database
+    ports:
+      - "{{ opennms_port }}:8980"
+      - "{{ opennms_port_karaf }}:8101"
+      - "{{ opennms_port_activemq }}:61616"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ opennms_user_id }}"
+      PGID: "{{ opennms_group_id }}"
+      POSTGRES_USER: "{{ opennms_sql_user }}"
+      POSTGRES_PASSWORD: "{{ opennms_sql_password }}"
+      OPENNMS_DBNAME: "{{ opennms_db_name }}"
+      OPENNMS_DBUSER: "{{ opennms_db_user }}"
+      OPENNMS_DBPASS: "{{ opennms_db_pass }}"
+    restart_policy: unless-stopped
+    memory: "{{ opennms_memory }}"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "-I", "http://localhost:8980/opennms/login.jsp" ]
+      interval: 1m
+      timeout: 5s
+      retries: 3
+    labels:
+      traefik.enable: "{{ opennms_available_externally }}"
+      traefik.http.routers.opennms.rule: "Host(`{{ opennms_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.opennms.tls.certresolver: "letsencrypt"
+      traefik.http.routers.opennms.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.opennms.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.opennms.loadbalancer.server.port: "{{ opennms_port }}"

--- a/roles/opennms/tasks/main.yml
+++ b/roles/opennms/tasks/main.yml
@@ -21,7 +21,7 @@
     restart_policy: unless-stopped
     memory: "{{ opennms_postgres_memory }}"
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
       timeout: 30s
       retries: 3
@@ -53,7 +53,7 @@
     restart_policy: unless-stopped
     memory: "{{ opennms_memory }}"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "-I", "http://localhost:8980/opennms/login.jsp" ]
+      test: ["CMD", "curl", "-f", "-I", "http://localhost:8980/opennms/login.jsp"]
       interval: 1m
       timeout: 5s
       retries: 3


### PR DESCRIPTION
What this PR does / why we need it:

Add [OpenNMS](https://www.opennms.com//), an open source enterprise grade network management application platform

Any other useful info:

Using this to monitor and diagnose home network outages. This application might be overkill for ansible-nas. I set it up, so I figured I'd put in a PR to let someone else decide.