### PR TITLE
[BUG] fix radarr memory limit

### DIFF
--- a/roles/radarr/defaults/main.yml
+++ b/roles/radarr/defaults/main.yml
@@ -16,4 +16,4 @@ radarr_port: "7878"
 radarr_hostname: "radarr"
 
 # specs
-pyload_memory: 1g
+radarr_memory: 1g

--- a/roles/radarr/tasks/main.yml
+++ b/roles/radarr/tasks/main.yml
@@ -22,7 +22,7 @@
       PUID: "{{ radarr_user_id }}"
       PGID: "{{ radarr_group_id }}"
     restart_policy: unless-stopped
-    memory: "{{ pyload_memory }}"
+    memory: "{{ radarr_memory }}"
     labels:
       traefik.enable: "{{ radarr_available_externally }}"
       traefik.http.routers.radarr.rule: "Host(`{{ radarr_hostname }}.{{ ansible_nas_domain }}`)"


### PR DESCRIPTION
**What this PR does / why we need it**:
Radarr role used pyload memory-limit. 
Added separated "radarr_memory" variable

