### PR TITLE
Fixes mismatch between Sonarr and NZBGet downloads directory 

### DIFF
--- a/roles/sonarr/tasks/main.yml
+++ b/roles/sonarr/tasks/main.yml
@@ -13,7 +13,7 @@
     pull: true
     volumes:
       - "{{ sonarr_tv_directory }}:/tv:rw"
-      - "{{ sonarr_download_directory }}/complete:/downloads:rw"
+      - "{{ sonarr_download_directory }}:/downloads:rw"
       - "{{ sonarr_data_directory }}:/config:rw"
     ports:
       - "{{ sonarr_port }}:8989"


### PR DESCRIPTION
**What this PR does / why we need it**:

It reduces configuration needs for Sonarr. Initializes Sonarr to have the same downloads location as NZBGet. NZBGet uses `/downloads/` and Sonarr uses `/downloads/complete/`. This confuses Sonarr when NZBGet tries to tell it where to get the file.
If this is not done, then you need to configure a remote path in Sonarr. This PR fixes that mismatch.