### PR TITLE
Fix typo in jellyfin config for books and audiobooks directories

### DIFF
--- a/tasks/jellyfin.yml
+++ b/tasks/jellyfin.yml
@@ -17,8 +17,8 @@
       - "{{ jellyfin_music_directory }}:/music:{{ jellyfin_music_permissions }}"
       - "{{ jellyfin_photos_directory }}:/photos:{{ jellyfin_photos_permissions }}"
       - "{{ jellyfin_tv_directory }}:/tv:{{ jellyfin_tv_permissions }}"
-      - "{{ jellyfin_books_directory }}:/books:{{ jellyfin_tv_permissions }}"
-      - "{{ jellyfin_audiobooks_directory }}:/audiobooks:{{ jellyfin_tv_permissions }}"
+      - "{{ jellyfin_books_directory }}:/books:{{ jellyfin_books_permissions }}"
+      - "{{ jellyfin_audiobooks_directory }}:/audiobooks:{{ jellyfin_audiobooks_permissions }}"
     ports:
       - "{{ jellyfin_port_http }}:8096"
       - "{{ jellyfin_port_https }}:8920"


### PR DESCRIPTION
Title basically sums it up - fixing a small Jellyfin config typo