### PR TITLE
Update integration hostname to match Vagrant VM name

### DIFF
--- a/tests/inventories/integration_testing/inventory
+++ b/tests/inventories/integration_testing/inventory
@@ -8,7 +8,7 @@
 
 
 [all]
-ansible-nas ansible_connection=local ansible_host=localhost
+ansible-nas-test ansible_connection=local ansible_host=localhost
 
 [nas]
-ansible-nas
+ansible-nas-test


### PR DESCRIPTION
**What this PR does / why we need it**:
Simple mismatch between the defined hostname created by the Vagrantfile and the integration testing inventory.

**Which issue (if any) this PR fixes**:
Fixes #483