### PR TITLE
Disable AppArmor via 'unconfined' profile

### DIFF
--- a/roles/glances/defaults/main.yml
+++ b/roles/glances/defaults/main.yml
@@ -8,5 +8,9 @@ glances_hostname: "glances"
 glances_port_one: "61208"
 glances_port_two: "61209"
 
+# security options
+glances_security_options:
+  - "apparmor=unconfined"
+
 # specs
 glances_memory: 1g

--- a/roles/glances/tasks/main.yml
+++ b/roles/glances/tasks/main.yml
@@ -14,6 +14,7 @@
     env:
       GLANCES_OPT: "-w"
     restart_policy: unless-stopped
+    security_opts: "{{ glances_security_options }}"
     memory: "{{ glances_memory }}"
     labels:
       traefik.enable: "{{ glances_available_externally }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
To stop log spamming by AppArmor. 

**Any other useful info**:
A better long-term solution might be to create (or find) a proper AppArmor profile ala https://docs.docker.com/engine/security/apparmor/. 