### PR TITLE
add booksonic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Ansible config and a bunch of Docker containers.
 * Various media management tools - Sonarr, Sickchill, CouchPotato, Radarr, Bazarr, Lidarr
 * Media streaming via Plex or Emby
 * Music streaming with Airsonic
+* Audiobook streaming with Booksonic
 * An RSS newsfeed reader - Miniflux
 * A Dropbox replacement via Nextcloud
 * Various ways to see stats about your NAS - Glances, dashboards in Grafana
@@ -36,6 +37,7 @@ Ansible config and a bunch of Docker containers.
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) - Self-Hosting port of password manager
+* [Booksonic](https://booksonic.org/) - The selfhosted audiobook server
 * [Calibre-web](https://github.com/janeczku/calibre-web) - Provides a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address

--- a/docs/applications/booksonic.md
+++ b/docs/applications/booksonic.md
@@ -1,0 +1,19 @@
+# Booksonic
+
+Homepage: [https://booksonic.org/](https://booksonic.org/)
+
+Stream your audiobooks to any pc or android phone. Most of the functionality is also available on other platforms that have apps for subsonic.
+
+Fully Open-Source. You can find the code on [GitHub](https://github.com/popeen?tab=repositories&q=booksonic)
+
+Get the Android app on [Google Play](https://play.google.com/store/apps/details?id=github.popeen.dsub) or build it from [source](https://github.com/popeen/Popeens-DSub)
+
+## Usage
+
+Set `booksonic_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The Booksonic web interface can be found at http://ansible_nas_host_or_ip:4041.
+
+## Specific Configuration
+
+The default username and password is `admin` - you'll need to change this immediately after logging in.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -8,6 +8,7 @@ By default, applications can be found on the ports listed below.
 | Bazarr          | 6767    | Bridge  | HTTP           |
 | Bitwarden "hub" | 3012    | Bridge  | Web Not.       |
 | Bitwarden       | 19080   | Bridge  | HTTP           |
+| Booksonic       | 4041    | Bridge  | HTTP           |
 | Calibre-web     | 8084    | Bridge  | HTTP           |
 | Cloud Commander | 7373    | Bridge  | HTTP           |
 | Couchpotato     | 5050    | Bridge  | HTTP           |

--- a/nas.yml
+++ b/nas.yml
@@ -58,6 +58,11 @@
         - bitwarden
       when: (bitwarden_enabled | default(False))
 
+    - role: booksonic
+      tags:
+        - booksonic
+      when: (booksonic_enabled | default(False))
+
     - role: cloudcmd
       tags:
         - cloudcmd

--- a/roles/booksonic/defaults/main.yml
+++ b/roles/booksonic/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+booksonic_enabled: false
+booksonic_available_externally: "false"
+
+# uid / gid
+booksonic_user_id: "1000"
+booksonic_group_id: "1000"
+
+# directories
+booksonic_data_directory: "{{ docker_home }}/booksonic"
+booksonic_audiobooks_directory: "{{ audiobooks_root }}"
+booksonic_podcasts_directory: "{{ podcasts_root }}"
+
+# network
+booksonic_port: "4041"
+booksonic_hostname: "booksonic"
+
+# specs
+booksonic_memory: 1g

--- a/roles/booksonic/tasks/main.yml
+++ b/roles/booksonic/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Create Booksonic Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+  with_items:
+    - "{{ booksonic_data_directory }}/data"
+    - "{{ booksonic_data_directory }}/playlists"
+
+- name: Booksonic Docker Container
+  docker_container:
+    name: booksonic
+    image: linuxserver/booksonic-air:latest
+    pull: true
+    volumes:
+      - "{{ booksonic_data_directory }}/data:/booksonic/data:rw"
+      - "{{ booksonic_data_directory }}/playlists:/booksonic/playlists:rw"
+      - "{{ booksonic_audiobooks_directory }}:/booksonic/audiobooks:rw"
+      - "{{ booksonic_podcasts_directory }}:/booksonic/podcasts:rw"
+    ports:
+      - "{{ booksonic_port }}:4040"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ booksonic_user_id }}"
+      PGID: "{{ booksonic_group_id }}"
+    restart_policy: unless-stopped
+    memory: "{{ booksonic_memory }}"
+    labels:
+      traefik.enable: "{{ booksonic_available_externally }}"
+      traefik.http.routers.booksonic.rule: "Host(`{{ booksonic_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.booksonic.tls.certresolver: "letsencrypt"
+      traefik.http.routers.booksonic.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.booksonic.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.booksonic.loadbalancer.server.port: "4040"


### PR DESCRIPTION
**What this PR does / why we need it**: Adds Booksonic, the selfhosted audiobook server, based on Airsonic

**Which issue (if any) this PR fixes**:

Fixes #487

**Any other useful info**:

This update is based on the Airsonic role with the port changed to 4041.

After playing with Booksonic for a bit, I decided not to use it for my home server. It just doesn't have the features I want. Someone may enjoy it.