### PR TITLE
correcting netbootxyz main.yml variable name error

### DIFF
--- a/roles/netbootxyz/tasks/main.yml
+++ b/roles/netbootxyz/tasks/main.yml
@@ -26,7 +26,7 @@
       PGID: "{{ netbootxyz_group_id }}"
     restart_policy: unless-stopped
     labels:
-      traefik.enable: "{{ netbootxyz_externally }}"
+      traefik.enable: "{{ netbootxyz_available_externally }}"
       traefik.http.routers.netdata.rule: "Host(`{{ netbootxyz_hostname }}.{{ ansible_nas_domain }}`)"
       traefik.http.routers.netdata.tls.certresolver: "letsencrypt"
       traefik.http.routers.netdata.tls.domains[0].main: "{{ ansible_nas_domain }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

netbootxyz_available_externally is the name in defaults, netbootxyz_externally was the name in main, just correcting so that both are netbootxyz_available_externally

**Any other useful info**:

fixes an error thrown during the netbootxyz portion of the playbook where it cannot locate {{ netbootxyz_externally }}
