### PR TITLE
traefik: add customization options

### DIFF
--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -9,18 +9,35 @@ traefik_enabled: false
 # directories
 traefik_data_directory: "{{ docker_home }}/traefik"
 
+# files
+traefik_template_files:
+  - src: traefik.toml.j2
+    dest: "{{ traefik_data_directory }}/traefik.toml"
+    force: "Yes"
+traefik_template_files_custom: []
+
 # network
 traefik_port_http: "80"
 traefik_port_https: "443"
 traefik_port_ui: "8083"
 
-traefik_docker_image: traefik:v2.4
+traefik_image: traefik:v2.5
+traefik_volumes:
+  - "{{ traefik_data_directory }}/letsencrypt:/letsencrypt:rw"
+  - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
+  - "/var/run/docker.sock:/var/run/docker.sock:ro"
+traefik_volumes_custom: []
 traefik_log_level: "INFO"
 
 # find the relevant name and environment variables for your DNS provider at https://go-acme.github.io/lego/dns/
 traefik_dns_provider: cloudflare
 traefik_environment_variables:
   CF_DNS_API_TOKEN: "abcdabcd123412341234"
+traefik_letsencrypt_tls: no
+
+traefik_domain_san:
+- "*.{{ ansible_nas_domain_root }}"
+traefik_domain_san_custom: []
 
 # Ansible-NAS requests a wildcard certificate for your domain, so there should be no reason to have to use the staging
 # letsencrypt acme server. If you do want to flip between staging/production, you might need to stop Traefik and clear

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -1,29 +1,41 @@
 ---
 - name: Create Traefik Directories
   file:
-    path: "{{ item }}"
-    state: directory
+    mode: "{{ item.mode | default('0750') }}"
+    path: "{{ item.path }}"
+    state: "directory"
+  tags:
+    - traefik
+    - traefik:dir
   with_items:
-    - "{{ traefik_data_directory }}"
-    - "{{ traefik_data_directory }}/letsencrypt"
+    - path: "{{ traefik_data_directory }}"
+      mode: "0755"
+    - path: "{{ traefik_data_directory }}/letsencrypt"
+      mode: "0700"
 
-- name: Template Traefik config.toml
-  template:
-    src: traefik.toml
-    dest: "{{ traefik_data_directory }}/traefik.toml"
+- name: Template Traefik Files
   register: template_config
+  tags:
+    - traefik
+    - traefik:template
+  template:
+    dest: "{{ item.dest }}"
+    force: "{{ item.force | default('No') }}"
+    mode: "{{ item.mode | default('0600') }}"
+    src: "{{ item.src }}"
+  with_items: "{{ traefik_template_files + traefik_template_files_custom | sort }}"
 
 - name: Traefik Docker Container
   docker_container:
-    name: traefik
-    image: "{{ traefik_docker_image }}"
-    pull: true
-    network_mode: host
-    volumes:
-      - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
-      - "{{ traefik_data_directory }}/letsencrypt:/letsencrypt:rw"
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
     env: "{{ traefik_environment_variables }}"
-    restart_policy: unless-stopped
+    image: "{{ traefik_image }}"
     memory: "{{ traefik_memory }}"
+    name: traefik
+    network_mode: host
+    pull: true
     recreate: "{{ template_config is changed }}"
+    restart_policy: unless-stopped
+    volumes: "{{ traefik_volumes + traefik_volumes_custom | sort }}"
+  tags:
+    - traefik
+    - traefik:docker

--- a/roles/traefik/templates/traefik.toml.j2
+++ b/roles/traefik/templates/traefik.toml.j2
@@ -1,6 +1,6 @@
 [entryPoints]
   [entryPoints.web]
-    address = ":80"
+    address = ":{{ traefik_port_http }}"
 
   [entryPoints.web.http.redirections.entryPoint]
     to = "websecure"
@@ -12,9 +12,9 @@
         certResolver = "letsencrypt"
 
         [entryPoints.websecure.http.tls.domains]
-          main = "{{ ansible_nas_domain }}"
+          main = "{{ ansible_nas_domain_root }}"
           sans = [
-            "*.{{ ansible_nas_domain }}"
+            "{{ (traefik_domain_san + traefik_domain_san_custom) | join("\",\n            \"") }}"
           ]
 
   [entryPoints.traefik]
@@ -30,7 +30,7 @@
   dashboard = true
 
 [log]
-  level = "{{ traefik_log_level }}"
+  level = "{{ traefik_log_level | upper }}"
 
 [ping]
   terminatingStatusCode = 0
@@ -44,3 +44,13 @@
 
       [certificatesResolvers.letsencrypt.acme.dnsChallenge]
         provider = "{{ traefik_dns_provider }}"
+
+{% if traefik_letsencrypt_tls %}
+  [certificatesResolvers.letsencryptTls]
+    [certificatesResolvers.letsencryptTls.acme]
+      email = "{{ ansible_nas_email }}"
+      storage = "/letsencrypt/acme.json"
+      caserver = "https://acme-v02.api.letsencrypt.org/directory"
+
+      [certificatesResolvers.letsencryptTls.acme.tlsChallenge]
+{% endif %}


### PR DESCRIPTION
- Updates traefik v2.4->v2.5 (I've done an in-place upgrade and it worked with no issues)
- Adds ability to even further customize traefik2 configuration but keeps all the current settings as default
    - parametrize container image using `traefik_image`
    - parametrize templated files with `traefik_template_files{,_custom}` template custom files
    - parametrize container volumes with `traefik_docker_volumes{,_custom}` mount custom volumes to container
    - parametrize entryPoint.web port `traefik_port_http`
    - use `ansible_nas_domain_root` as added in #495 to allow more customization for domain names
    - parametrize domains used to generate certificates using `traefik_domain_san{,_custom}`
- Optionaly add `certificatesResolvers.letsencryptTls` that uses TLS to authenticate for domain certificates, usefull if you have some domains that aren't using default `ansible_nas_domain` or `*.ansible_nas_domain` domain

Example for templating:
I'm using this to seed the account-file.json to multiple server that I use as a failover. `acme-dns` uses it to store the "passwords" for domain certs it tries to / issues.