### PR TITLE
WIP: nextcloud: use nginx, allow detailed user customization

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -5,15 +5,70 @@ nextcloud_available_externally: "false"
 # directories
 nextcloud_data_directory: "{{ docker_home }}/nextcloud"
 
-# network
-nextcloud_port: "8080"
-nextcloud_hostname: "nextcloud"
+# data subdirectories
+nextcloud_data_subdirectories:
+  - "{{ nextcloud_data_directory }}/nextcloud"
+  - "{{ nextcloud_data_directory }}/mysql"
+nextcloud_data_subdirectories_custom: []
 
-# username / passwords
+nextcloud_utils_enabled: false
+nextcloud_utils_templates: []
+nextcloud_utils_logrotate_path: "/etc/logrotate.d/nextcloud"
+nextcloud_utils_log_path: "nextcloud/data/nextcloud.log"
+
+# SQL
+nextcloud_sql_image: "mysql:8.0"
+nextcloud_sql_memory: 1g
 nextcloud_sql_user: "nextcloud-user"
 nextcloud_sql_password: "nextcloud-pass"
 nextcloud_sql_root_password: "nextcloud-secret"
+nextcloud_sql_volumes:
+  - "{{ nextcloud_data_directory }}/mysql:/var/lib/mysql:rw"
+nextcloud_sql_volumes_custom: []
 
-# specs
+# Nextcloud
+nextcloud_image: nextcloud:22.2.0
+nextcloud_image_fpm: nextcloud:22.2.0-fpm
 nextcloud_memory: 1g
-nextcloud_mysql_memory: 1g
+nextcloud_port: "8080"
+nextcloud_hostname: "nextcloud"
+nextcloud_volumes:
+  - "{{ nextcloud_data_directory }}/nextcloud:/var/www/html:rw"
+nextcloud_volumes_custom: []
+nextcloud_labels:
+  traefik.enable: "{{ nextcloud_available_externally }}"
+  traefik.http.routers.nextcloud.rule: "Host(`{{ nextcloud_domain }}`)"
+  traefik.http.routers.nextcloud.tls.certresolver: "letsencrypt"
+  traefik.http.routers.nextcloud.tls.domains[0].main: "{{ nextcloud_domain }}"
+  traefik.http.routers.nextcloud.middlewares: "nc-dav@docker,nc-wellknown@docker,nc-header@docker"
+  traefik.http.services.nextcloud.loadbalancer.server.port: "80"
+  traefik.http.services.nextcloud.loadbalancer.passhostheader: "true"
+  traefik.http.middlewares.nc-dav.replacepathregex.regex: "^/.well-known/ca(l|rd)dav"
+  traefik.http.middlewares.nc-dav.replacepathregex.replacement: "/remote.php/dav/"
+  traefik.http.middlewares.nc-wellknown.replacepathregex.regex: "^(/.well-known/.*)"
+  traefik.http.middlewares.nc-wellknown.replacepathregex.replacement: "/index.php$${1}"
+  traefik.http.middlewares.nc-header.headers.referrerPolicy: "no-referrer"
+  traefik.http.middlewares.nc-header.headers.stsSeconds: "15552000"
+  traefik.http.middlewares.nc-header.headers.forceSTSHeader: "true"
+  traefik.http.middlewares.nc-header.headers.stsPreload: "true"
+  traefik.http.middlewares.nc-header.headers.stsIncludeSubdomains: "true"
+  traefik.http.middlewares.nc-header.headers.browserXssFilter: "true"
+  traefik.http.middlewares.nc-header.headers.customFrameOptionsValue: "SAMEORIGIN"
+  traefik.http.middlewares.nc-header.headers.contentSecurityPolicy: "default-src 'self';\
+    frame-ancestors 'self';\
+    style-src 'self' 'unsafe-inline';\
+    script-src 'self' 'unsafe-inline' 'unsafe-eval';\
+    img-src 'self' data:;\
+    font-src 'self' data:;"
+  # traefik.http.middlewares.nc-header.headers.customRequestHeaders: "X-Forwarded-Proto=https"
+  # traefik.frontend.rule: "Host:{{ nextcloud_domain | default('{{ nextcloud_hostname }}.{{ ansible_nas_domain }}') }}"
+
+nextcloud_labels_httpd: "{{ {} if nextcloud_nginx_enabled else nextcloud_labels }}"
+
+# Nginx
+nextcloud_nginx_enabled: false
+nextcloud_nginx_image: nginx
+nextcloud_nginx_memory: 128m
+nextcloud_nginx_volumes:
+  - "{{ nextcloud_data_directory }}/nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
+nextcloud_nginx_volumes_custom: []

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -1,50 +1,61 @@
 ---
-- name: Create Nextcloud directories
+- name: Create directories
   file:
     path: "{{ item }}"
     state: directory
-  with_items:
-    - "{{ nextcloud_data_directory }}/nextcloud"
-    - "{{ nextcloud_data_directory }}/mysql"
+    mode: '0755'
+  with_items: "{{ nextcloud_data_subdirectories + nextcloud_data_subdirectories_custom | sort }}"
+  tags:
+    - nextcloud:dir
 
-- name: Nextcloud Mysql Docker Container
+- name: Utils
+  include_tasks: utils.yml
+  tags:
+    - nextcloud:utils
+  when: nextcloud_utils_enabled
+
+- name: Mysql Container
   docker_container:
     name: nextcloud-mysql
-    image: mysql:5.7
+    image: "{{ nextcloud_sql_image }}"
     pull: true
-    volumes:
-      - "{{ nextcloud_data_directory }}/mysql:/var/lib/mysql:rw"
+    volumes: "{{ nextcloud_sql_volumes + nextcloud_sql_volumes_custom | sort }}"
     env:
       MYSQL_DATABASE: "nextcloud"
       MYSQL_USER: "{{ nextcloud_sql_user }}"
       MYSQL_PASSWORD: "{{ nextcloud_sql_password }}"
       MYSQL_ROOT_PASSWORD: "{{ nextcloud_sql_root_password }}"
     restart_policy: unless-stopped
-    memory: "{{ nextcloud_mysql_memory }}"
+    memory: "{{ nextcloud_sql_memory }}"
+    capabilities:
+      - sys_nice
+    container_default_behavior: compatibility
+  tags:
+    - nextcloud:sql
 
-- name: Nextcloud Docker Container
+- name: Nextcloud Container
   docker_container:
     name: nextcloud
-    image: nextcloud:14
+    image: "{{ nextcloud_image_fpm if nextcloud_nginx_enabled else nextcloud_image }}"
     pull: true
     links:
       - nextcloud-mysql:mysql
-    volumes:
-      - "{{ nextcloud_data_directory }}/nextcloud:/var/www/html:rw"
-    ports:
-      - "{{ nextcloud_port }}:80"
+    volumes: "{{ nextcloud_volumes + nextcloud_volumes_custom }}"
     env:
       MYSQL_HOST: "mysql"
       MYSQL_DATABASE: "nextcloud"
       MYSQL_USER: "{{ nextcloud_sql_user }}"
       MYSQL_PASSWORD: "{{ nextcloud_sql_password }}"
-      NEXTCLOUD_TRUSTED_DOMAINS: "{{ nextcloud_hostname }}.{{ ansible_nas_domain }}"
+      NEXTCLOUD_TRUSTED_DOMAINS: "{{ nextcloud_trusted_domains | default([nextcloud_hostname,ansible_nas_domain] | concat('.')) }}"
     restart_policy: unless-stopped
-    memory: "{{ nextcloud_memory }}"
-    labels:
-      traefik.enable: "{{ nextcloud_available_externally }}"
-      traefik.http.routers.nextcloud.rule: "Host(`{{ nextcloud_hostname }}.{{ ansible_nas_domain }}`)"
-      traefik.http.routers.nextcloud.tls.certresolver: "letsencrypt"
-      traefik.http.routers.nextcloud.tls.domains[0].main: "{{ ansible_nas_domain }}"
-      traefik.http.routers.nextcloud.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
-      traefik.http.services.nextcloud.loadbalancer.server.port: "80"
+    memory: "{{ nextcloud_sql_memory }}"
+    labels: "{{ {} if nextcloud_nginx_enabled else nextcloud_labels }}"
+    container_default_behavior: compatibility
+  tags:
+    - nextcloud:php
+
+- name: Nginx
+  include_tasks: nginx.yml
+  tags:
+    - nextcloud:nginx
+  when: nextcloud_nginx_enabled

--- a/roles/nextcloud/tasks/nginx.yml
+++ b/roles/nextcloud/tasks/nginx.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Nginx Docker Container
+  docker_container:
+    container_default_behavior: compatibility
+    name: nextcloud-nginx
+    image: "{{ nextcloud_nginx_image }}"
+    ports:
+      - "{{ nextcloud_port }}:80"
+    links:
+      - nextcloud
+    volumes: "{{ nextcloud_nginx_volumes + nextcloud_nginx_volumes_custom }}"
+    volumes_from:
+      - nextcloud
+    restart_policy: unless-stopped
+    memory: "{{ nextcloud_nginx_memory }}"
+    labels: "{{ nextcloud_labels }}"

--- a/roles/nextcloud/tasks/utils.yml
+++ b/roles/nextcloud/tasks/utils.yml
@@ -1,0 +1,35 @@
+---
+
+- name: Template files
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: '0644'
+  with_items: "{{ nextcloud_utils_templates }}"
+  tags:
+    - nextcloud:template
+
+- name: Cronjob "php -f cron.php"
+  cron:
+    name: "nextcloud cronjob"
+    minute: "*/5"
+    job: "docker exec --user www-data nextcloud php -f cron.php > /dev/null 2>&1"
+  tags:
+    - nextcloud:cronjob
+
+- name: Logrotate setup
+  blockinfile:
+    path: "{{ nextcloud_utils_logrotate_path }}"
+    block: |
+      {{ nextcloud_data_directory }}/{{ nextcloud_utils_log_path }} {
+        weekly
+        rotate 8
+        size 10M
+        compress
+        delaycompress
+        su www-data www-data
+      }
+    create: true
+    mode: '0644'
+  tags:
+    - nextcloud:logrotate


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows nextcloud to use nginx as the web server
- still allows the use of default image: nextcloud:x.y.z
- adds optional nginx
- adds some missing rewrites for .well-known ~ dav, webfinger, nodeinfo
- allows custom container volumes to be mounted
- you can create custom sub directories under `nextcloud_data_directory` to separate data out of the web folder
- adds logrotate to rotate nextcloud.log just in case something starts to write to much to it *TODO* ability to disable if not required
- adds cronjob for nextcloud *TODO* ability to disable if not using system cron in settings
- *TODO* add nginx.conf in templates, fix path to nginx template and check if any other file is missing

**Any other useful info**:
I am using ZFS and this allows me to better separate what datasets I want to snapshot and send over to a backup server. And I already had a non docker installation utilizing nginx when I started using Ansible-NAS so it was simpler for me to adopt this.