### PR TITLE
syncthing: don't run in host network mode, specify uid/gid

### DIFF
--- a/roles/syncthing/defaults/main.yml
+++ b/roles/syncthing/defaults/main.yml
@@ -12,6 +12,10 @@ syncthing_data_directory: "{{ samba_shares_root }}/syncthing"
 syncthing_volumes:
   - "{{ syncthing_data_directory }}:/var/syncthing/"
 
+syncthing_user_id: "0"
+syncthing_group_id: "0"
+
+
 # network
 syncthing_port: 8384
 syncthing_hostname: syncthing

--- a/roles/syncthing/tasks/main.yml
+++ b/roles/syncthing/tasks/main.yml
@@ -11,7 +11,13 @@
     name: syncthing
     image: syncthing/syncthing:latest
     pull: true
-    network_mode: host
+    ports:
+      - "8384:8384"
+      - "22000:22000/tcp"
+      - "22000:22000/udp"
+    env:
+      PUID: "{{ syncthing_user_id }}"
+      PGID: "{{ syncthing_group_id }}"
     volumes: "{{ syncthing_volumes }}"
     restart_policy: unless-stopped
     memory: "{{ syncthing_memory }}"

--- a/roles/syncthing/tasks/main.yml
+++ b/roles/syncthing/tasks/main.yml
@@ -12,7 +12,7 @@
     image: syncthing/syncthing:latest
     pull: true
     ports:
-      - "8384:8384"
+      - "{{ syncthing_port }}:8384"
       - "22000:22000/tcp"
       - "22000:22000/udp"
     env:


### PR DESCRIPTION
**What this PR does / why we need it**:
- adds ability to specify as which user syncthing should run (files can have owner other then root)
- removes requirement to run syncthing in host network mode.