### PR TITLE
new role: qbittorrent-with-openvpn

### DIFF
--- a/nas.yml
+++ b/nas.yml
@@ -263,6 +263,11 @@
         - transmission_with_openvpn
       when: (transmission_with_openvpn_enabled | default(False))
 
+    - role: qbittorrent-with-openvpn
+      tags:
+        - qbittorrent_with_openvpn
+      when: (qbittorrent_with_openvpn_enabled | default(False))
+
     - role: utorrent
       tags:
         - utorrent

--- a/roles/qbittorrent-with-openvpn/defaults/main.yml
+++ b/roles/qbittorrent-with-openvpn/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+qbittorrent_with_openvpn_enabled: false # Please see docs about how to set VPN credentials
+qbittorrent_with_openvpn_available_externally: "false"
+
+# directories
+qbittorrent_data_directory: "{{ docker_home }}/qbittorrent"
+qbittorrent_config_directory: "{{ qbittorrent_data_directory }}/config"
+qbittorrent_download_directory: "{{ downloads_root }}"
+qbittorrent_watch_directory: "{{ torrents_root }}"
+
+# uid / gid
+qbittorrent_openvpn_user_id: "0"
+qbittorrent_openvpn_group_id: "0"
+
+# qbittorrent config
+qbittorrent_openvpn_ratio_limit_enabled: "true"
+qbittorrent_openvpn_ratio_limit: "2"
+qbittorrent_openvpn_local_network: "192.168.1.0/24"
+qbittorrent_openvpn_ipwhitelist: "192.168.1.0/24" # multi subnet example: "192.168.1.0/24,169.254.0.1/24"
+
+# network config
+qbittorrent_openvpn_webui_port: "8091"
+qbittorrent_openvpn_external_port: "51415"
+qbittorrent_openvpn_proxy_port: "3128"
+qbittorrent_openvpn_hostname: "qbittorrent_openvpn"
+
+# qbittorrent VPN Credentials
+# If you're using qbittorrent with a VPN, you'll need to set these credentials.
+# See https://github.com/haugene/docker-qbittorrent-openvpn/ for supported VPN providers.
+openvpn_username: leisure-suit-larry
+openvpn_password: secretpassword
+openvpn_provider: AWESOMEVPNPROVIDER
+openvpn_config: United-Kingdom
+
+# specs
+qbittorrent_openvpn_memory: 1g

--- a/roles/qbittorrent-with-openvpn/tasks/main.yml
+++ b/roles/qbittorrent-with-openvpn/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Create qBittorrent Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    # mode: 0755
+  with_items:
+    - "{{ qbittorrent_data_directory }}"
+    - "{{ qbittorrent_data_directory }}/config"
+    - "{{ qbittorrent_data_directory }}/openvpn"
+    - "{{ qbittorrent_download_directory }}"
+    - "{{ qbittorrent_watch_directory }}"
+
+- name: qbittorrent with VPN
+  docker_container:
+    name: qbittorrent-openvpn
+    image: guillaumedsde/alpine-qbittorrent-openvpn:python
+    pull: true
+    volumes:
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
+      - "{{ qbittorrent_data_directory }}/config:/config:rw"
+      - "{{ qbittorrent_data_directory }}/openvpn:/etc/openvpn/custom:rw"
+      - "{{ qbittorrent_download_directory }}:/downloads:rw"
+    ports:
+      - "{{ qbittorrent_openvpn_webui_port }}:8080"
+    env:
+      OPENVPN_PROVIDER: "{{ openvpn_provider }}"
+      OPENVPN_USERNAME: "{{ openvpn_username }}"
+      OPENVPN_PASSWORD: "{{ openvpn_password }}"
+      OPENVPN_CONFIG: "{{ openvpn_config }}"
+      PUID: "{{ qbittorrent_openvpn_user_id }}"
+      PGID: "{{ qbittorrent_openvpn_group_id }}"
+      LAN: "{{ qbittorrent_openvpn_local_network }}"
+    devices:
+      - /dev/net/tun
+    capabilities:
+      - NET_ADMIN
+    restart_policy: unless-stopped
+    memory: "{{ qbittorrent_openvpn_memory }}"
+    labels:
+      traefik.enable: "{{ qbittorrent_with_openvpn_available_externally }}"
+      traefik.http.routers.qbittorrent_openvpn.rule: "Host(`{{ qbittorrent_openvpn_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.qbittorrent_openvpn.tls.certresolver: "letsencrypt"
+      traefik.http.routers.qbittorrent_openvpn.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.qbittorrent_openvpn.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.qbittorrent_openvpn.loadbalancer.server.port: "8080"
+      traefik.http.routers.qbittorrent_openvpn.middlewares: "qbittorrent-ipwhitelist@docker"
+      traefik.http.middlewares.qbittorrent-ipwhitelist.sourcerange: "{{ qbittorrent_openvpn_ipwhitelist }}"
+      traefik.http.middlewares.qbittorrent-ipwhitelist.ipwhitelist.ipstrategy.depth: "0"


### PR DESCRIPTION
**What this PR does / why we need it**:
- adds qbittorent with openvpn which is based on transmisison with openvpn

**Any other useful info**:
- transmisison lacks some integration with sonarr and radarr where you can add a torret to it and get it picked up by them, qbittorent handles that nicely