### PR TITLE
Add UniFi Network Application stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Ansible config and a bunch of Docker containers.
 * [Traefik](https://traefik.io/) - Web proxy and SSL certificate manager
 * [Transmission](https://transmissionbt.com/) - BitTorrent client (with OpenVPN if you have a supported VPN provider)
 * [Ubooquity](http://vaemendis.net/ubooquity/) - Book and comic server
+* [UniFi Network Application](https://help.ui.com/hc/en-us/articles/360012282453) - Self-host UniFi Network Application to manage UniFi devices
 * [uTorrent](https://www.utorrent.com/) - The best torrent downloading app for beginners
 * [Virtual Desktop](https://github.com/RattyDAVE/docker-ubuntu-xrdp-mate-custom) - A virtual desktop running on your NAS.
 * [Wallabag](https://wallabag.org/) - Save and classify articles. Read them later.

--- a/docs/applications/unifi.md
+++ b/docs/applications/unifi.md
@@ -1,0 +1,28 @@
+
+# UniFi Network Application
+
+Homepage: [https://help.ui.com/hc/en-us/articles/360012282453](https://help.ui.com/hc/en-us/articles/360012282453)
+
+UniFi Network Application is used to control UniFi Network devices from Ubiquiti.
+
+## Usage
+
+Set `unifi_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+UniFi runs as UID/GID 999 which is allocated to `systemd-coredump` on Ubuntu.
+If necessary, create user and group with id 999, and define the user as
+`unifi_user` and `unifi_group` respectively.
+
+The defaults are
+
+```yaml
+unifi_user: "systemd-coredump"
+unifi_group: "systemd-coredump"
+```
+
+Timezone setting defaults to `ansible_nas_timezone`, but you can override it
+by setting `unifi_timezone`.
+
+The UniFi web interface can be found at https://ansible_nas_host_or_ip:8443.
+Note that you need to use HTTPS in order for the initial setup and device
+adoption to go through.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -79,6 +79,13 @@ By default, applications can be found on the ports listed below.
 | Transmission    | 9092    | Bridge  | HTTP Internal  |
 | Ubooquity       | 2202    | Bridge  | HTTP Internal  |
 | Ubooquity       | 2203    | Bridge  | HTTP Admin     |
+| UniFi           | 3478    | Custom  | STUN           |
+| UniFi           | 6789    | Custom  | Speedtest      |
+| UniFi           | 8080    | Custom  | Device comm    |
+| UniFi           | 8443    | Custom  | HTTPS GUI      |
+| UniFi           | 8880    | Custom  | HTTP Portal    |
+| UniFi           | 8843    | Custom  | HTTPS Portal   |
+| UniFi           | 10001   | Custom  | AP discovery   |
 | uTorrent        | 8111    | Bridge  | HTTP           |
 | uTorrent        | 6881    | Bridge  | BT             |
 | uTorrent        | 6881    | Bridge  | UDP            |

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -396,3 +396,14 @@ vd_users:
     password: "topsecret"
     sudo: "Y"
 vd_rdp_port: 3389
+
+###
+### UniFi Network Application
+###
+unifi_data_directory: "{{ docker_home }}/unifi"
+unifi_network_name: "unifi"
+unifi_user: "systemd-coredump"
+unifi_group: "systemd-coredump"
+unifi_memory: 1g
+unifi_mongodb_memory: 1g
+unifi_timezone: "{{ ansible_nas_timezone }}"

--- a/nas.yml
+++ b/nas.yml
@@ -263,6 +263,11 @@
         - transmission_with_openvpn
       when: (transmission_with_openvpn_enabled | default(False))
 
+    - role: unifi
+      tags:
+        - unifi
+      when: (unifi_enabled | default(False))
+
     - role: utorrent
       tags:
         - utorrent

--- a/roles/unifi/defaults/main.yml
+++ b/roles/unifi/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+unifi_enabled: false
+
+# directories
+unifi_data_directory: "{{ docker_home }}/unifi"
+
+# network
+unifi_network_name: "unifi"
+
+# user / group name
+unifi_user: "systemd-coredump"
+unifi_group: "systemd-coredump"
+
+# specs
+unifi_memory: 1g
+unifi_mongodb_memory: 1g
+
+# timezone
+unifi_timezone: "{{ ansible_nas_timezone }}"

--- a/roles/unifi/tasks/main.yml
+++ b/roles/unifi/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+- name: Create UniFi Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ unifi_user }}"
+    group: "{{ unifi_group }}"
+    recurse: yes
+  with_items:
+    - "{{ unifi_data_directory }}/data"
+    - "{{ unifi_data_directory }}/log"
+    - "{{ unifi_data_directory }}/cert"
+    - "{{ unifi_data_directory }}/init"
+    - "{{ unifi_data_directory }}/run"
+    - "{{ unifi_data_directory }}/backup"
+    - "{{ unifi_data_directory }}/mongodb"
+    - "{{ unifi_data_directory }}/mongodbcfg"
+
+- name: Create Docker network for UniFi
+  docker_network:
+    name: "{{ unifi_network_name }}"
+
+- name: Create MongoDB container for UniFi
+  docker_container:
+    name: unifi-mongo
+    image: mongo:3.6
+    pull: true
+    network_mode: "{{ unifi_network_name }}"
+    networks:
+      - name: "{{ unifi_network_name }}"
+    volumes:
+      - "{{ unifi_data_directory }}/mongodb:/data/db:rw"
+      - "{{ unifi_data_directory }}/mongodbcfg:/data/configdb:rw"
+    restart_policy: unless-stopped
+    container_default_behavior: no_defaults
+    memory: "{{ unifi_mongodb_memory }}"
+
+- name: Create UniFi container
+  docker_container:
+    name: unifi-controller
+    image: jacobalberty/unifi:latest
+    pull: true
+    user: unifi
+    sysctls:
+      net.ipv4.ip_unprivileged_port_start: 0
+    network_mode: "{{ unifi_network_name }}"
+    networks:
+      - name: "{{ unifi_network_name }}"
+        links:
+          - unifi-mongo:mongo
+    volumes:
+      - "{{ unifi_data_directory }}/backup:/unifi/data/backup:rw"
+      - "{{ unifi_data_directory }}/data:/unifi/data:rw"
+      - "{{ unifi_data_directory }}/log:/unifi/log:rw"
+      - "{{ unifi_data_directory }}/cert:/unifi/cert:rw"
+      - "{{ unifi_data_directory }}/init:/unifi/init.d:rw"
+      - "{{ unifi_data_directory }}/run:/var/run/unifi:rw"
+      - "{{ unifi_data_directory }}:/unifi:rw"
+    ports:
+      - "3478:3478/udp" # STUN
+      - "6789:6789/tcp" # Speed test
+      - "8080:8080/tcp" # Device/controller communication
+      - "8443:8443/tcp" # Controller GUI/API as seen in a web browser
+      - "8880:8880/tcp" # HTTP portal redirection
+      - "8843:8843/tcp" # HTTPS portal redirection
+      - "10001:10001/udp" # AP discovery
+    env:
+      DB_URI: mongodb://mongo/unifi
+      STATDB_URI: mongodb://mongo/unifi_stat
+      DB_NAME: unifi
+      TZ: "{{ unifi_timezone }}"
+      UNIFI_GID: "999"
+      UNIFI_UID: "999"
+      RUNAS_UID0: "false"
+    restart_policy: unless-stopped
+    container_default_behavior: no_defaults
+    memory: "{{ unifi_memory }}"
+
+- name: Create log watch container for UniFi
+  docker_container:
+    name: unifi-logs
+    image: bash
+    pull: true
+    network_mode: "{{ unifi_network_name }}"
+    networks:
+      - name: "{{ unifi_network_name }}"
+        links:
+          - unifi-controller:controller
+    volumes:
+      - "{{ unifi_data_directory }}/log:/unifi/log:ro"
+    restart_policy: unless-stopped
+    container_default_behavior: no_defaults
+    command: "bash -c 'tail -F /unifi/log/*.log'"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

This adds [UniFi Network Application](https://help.ui.com/hc/en-us/articles/360012282453) stack to Ansible-NAS. This is a valuable addition to any owners of [Ubiquiti UniFi products](https://ui.com/consoles), since it completely replaces a separate UniFi Cloud Key or manually deploying the Network Application stack.

**Any other useful info**:

The unifi-docker container is provided by [Jacob Alberty](https://github.com/jacobalberty/unifi-docker), and the stack is based on their Docker Compose example. We define a separate network (`unifi`) for the stack to assert the default ports can always be used.

We run our Ansible-NAS on UTC timezone, but prefer having UniFi controller on the local TZ. That's why the TZ for the UniFi container can be overwritten with `unifi_timezone`