### PR TITLE
add mealie

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Ansible config and a bunch of Docker containers.
 * [Komga](https://komga.org/) - a media server for your comics, mangas, BDs and magazines
 * [Krusader](https://krusader.org/) - Twin panel file management for your desktop
 * [Lidarr](https://github.com/lidarr/Lidarr) - Music collection manager for Usenet and BitTorrent users
+* [Mealie](https://hay-kot.github.io/mealie/) - A self-hosted recipe manager and meal planner
 * [MiniDLNA](https://sourceforge.net/projects/minidlna/) - simple media server which is fully compliant with DLNA/UPnP-AV clients
 * [Miniflux](https://miniflux.app/) - An RSS news reader
 * [Mosquitto](https://mosquitto.org) - An open source MQTT broker

--- a/docs/applications/mealie.md
+++ b/docs/applications/mealie.md
@@ -1,0 +1,11 @@
+# Mealie
+
+Homepage: [https://docs.mealie.io/](https://docs.mealie.io/)
+
+A self-hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family.
+
+## Usage
+
+Set `mealie_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The Mealie web interface can be found at http://ansible_nas_host_or_ip:9925.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -41,6 +41,7 @@ By default, applications can be found on the ports listed below.
 | Krusader        | 5800    | Bridge  | HTTP           |
 | Krusader        | 5900    | Bridge  | VNC            |
 | Lidarr          | 8686    | Bridge  | HTTP           |
+| Mealie          | 9925    | Host    | HTTP           |
 | MiniDLNA        | 8201    | Host    | HTTP           |
 | Miniflux        | 8070    | Bridge  | HTTP           |
 | Mosquitto       | 1883    | Bridge  | Websocket      |

--- a/nas.yml
+++ b/nas.yml
@@ -158,6 +158,11 @@
         - lidarr
       when: (lidarr_enabled | default(False))
 
+    - role: mealie
+      tags:
+        - mealie
+      when: (mealie_enabled | default(False))
+
     - role: minidlna
       tags:
         - minidlna

--- a/roles/mealie/defaults/main.yml
+++ b/roles/mealie/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+mealie_enabled: false
+mealie_available_externally: "false"
+
+# directories
+mealie_data_directory: "{{ docker_home }}/mealie"
+
+# uid / gid
+mealie_user_id: "1000"
+mealie_group_id: "1000"
+
+# network
+mealie_hostname: "mealie"
+mealie_port: "9925"
+
+# specs
+mealie_memory: 1g

--- a/roles/mealie/tasks/main.yml
+++ b/roles/mealie/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Create Mealie Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ mealie_data_directory }}/data"
+
+- name: Mealie Docker Container
+  docker_container:
+    name: mealie
+    image: hkotel/mealie:latest
+    pull: true
+    volumes:
+      - "{{ mealie_data_directory }}:/app/data:rw"
+    ports:
+      - "{{ mealie_port }}:80"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ mealie_user_id }}"
+      PGID: "{{ mealie_group_id }}"
+      RECIPE_PUBLIC: 'true'
+      RECIPE_SHOW_NUTRITION: 'true'
+      RECIPE_SHOW_ASSETS: 'true'
+      RECIPE_LANDSCAPE_VIEW: 'true'
+      RECIPE_DISABLE_COMMENTS: 'false'
+      RECIPE_DISABLE_AMOUNT: 'false'
+      BASE_URL: "{{ ansible_nas_domain }}:{{ mealie_port }}"
+    restart_policy: unless-stopped
+    memory: "{{ mealie_memory }}"
+    labels:
+      traefik.enable: "{{ mealie_available_externally }}"
+      traefik.http.routers.mealie.rule: "Host(`{{ mealie_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.mealie.tls.certresolver: "letsencrypt"
+      traefik.http.routers.mealie.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.mealie.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.mealie.loadbalancer.server.port: "80"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add [Mealie](https://hay-kot.github.io/mealie/). A self-hosted recipe manager and meal planner with a RestAPI backend and a reactive frontend application built in Vue for a pleasant user experience for the whole family. 

**Which issue (if any) this PR fixes**:

Fixes #519

**Any other useful info**:

This was really easy to set up. My wife is excited.