### PR TITLE
ESPHome

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Ansible config and a bunch of Docker containers.
 * [Duplicacy](https://duplicacy.com/) - A web UI for the Duplicacy cloud backup program, which provides lock-free deduplication backups to multiple providers
 * [Duplicati](https://www.duplicati.com/) - for backing up your stuff
 * [Emby](https://emby.media/) - Media streaming and management
+* [ESPHome](https://esphome.io/) - ESP8266/ESP32 programming and management for home automation
 * [Firefly III](https://firefly-iii.org/) - Free and open source personal finance manager
 * [get_iplayer](https://github.com/get-iplayer/get_iplayer) - download programmes from BBC iplayer
 * [Gitea](https://gitea.io/en-us/) - Simple self-hosted GitHub clone

--- a/docs/applications/esphome.md
+++ b/docs/applications/esphome.md
@@ -8,4 +8,6 @@ ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configu
 
 Set `esphome_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
 
+You can make esphome externally available, but the program has no security so this is strongly not advised. 
+
 The EspHome web interface can be found at http://ansible_nas_host_or_ip:6052.

--- a/docs/applications/esphome.md
+++ b/docs/applications/esphome.md
@@ -1,0 +1,11 @@
+# EspHome
+
+Homepage: [esphome.io](https://esphome.io/)
+
+ESPHome is a system to control your ESP8266/ESP32 by simple yet powerful configuration files and control them remotely through Home Automation systems. 
+
+## Usage
+
+Set `esphome_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The EspHome web interface can be found at http://ansible_nas_host_or_ip:6052.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -18,6 +18,7 @@ By default, applications can be found on the ports listed below.
 | Emby            | 8096    | Bridge  | HTTP           |
 | Emby            | 8096    | Bridge  | HTTP           |
 | Emby            | 8920    | Bridge  | HTTPS          |
+| EspHome         | 6052    | Bridge  | HTTP           |
 | Firefly III     | 8066    | Bridge  | HTTP           |
 | get_iplayer     | 8182    | Bridge  | HTTP           |
 | Gitea           | 3001    | Bridge  | HTTP           |

--- a/nas.yml
+++ b/nas.yml
@@ -98,6 +98,11 @@
         - emby
       when: (emby_enabled | default(False))
 
+    - role: esphome
+      tags:
+        - esphome
+      when: (esphome_enabled | default(False))
+
     - role: firefly
       tags:
         - firefly

--- a/roles/esphome/defaults/main.yml
+++ b/roles/esphome/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+esphome_enabled: false
+esphome_available_externally: "false"
+
+# directories
+esphome_data_directory: "{{ docker_home }}/esphome"
+
+# uid / gid
+esphome_user_id: "1000"
+esphome_group_id: "1000"
+
+# network
+esphome_hostname: "esphome"
+esphome_port: "6052"
+
+# specs
+esphome_memory: 1g

--- a/roles/esphome/tasks/main.yml
+++ b/roles/esphome/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Create EspHome Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ esphome_data_directory }}/data"
+
+- name: EspHome Docker Container
+  docker_container:
+    name: esphome
+    image: esphome/esphome:latest
+    pull: true
+    volumes:
+      - "{{ esphome_data_directory }}:/config/esphome/data:rw"
+    ports:
+      - "{{ esphome_port }}:80"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      PUID: "{{ esphome_user_id }}"
+      PGID: "{{ esphome_group_id }}"
+    restart_policy: unless-stopped
+    memory: "{{ esphome_memory }}"
+    labels:
+      traefik.enable: "{{ esphome_available_externally }}"
+      traefik.http.routers.esphome.rule: "Host(`{{ esphome_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.esphome.tls.certresolver: "letsencrypt"
+      traefik.http.routers.esphome.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.esphome.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.esphome.loadbalancer.server.port: "80"

--- a/roles/esphome/tasks/main.yml
+++ b/roles/esphome/tasks/main.yml
@@ -14,7 +14,7 @@
     volumes:
       - "{{ esphome_data_directory }}:/config/esphome/data:rw"
     ports:
-      - "{{ esphome_port }}:80"
+      - "{{ esphome_port }}:6052"
     env:
       TZ: "{{ ansible_nas_timezone }}"
       PUID: "{{ esphome_user_id }}"

--- a/roles/esphome/tasks/main.yml
+++ b/roles/esphome/tasks/main.yml
@@ -12,7 +12,8 @@
     image: esphome/esphome:latest
     pull: true
     volumes:
-      - "{{ esphome_data_directory }}:/config/esphome/data:rw"
+      - "{{ esphome_data_directory }}:/config:rw"
+      - "/etc/localtime:/etc/localtime:ro"
     ports:
       - "{{ esphome_port }}:6052"
     env:


### PR DESCRIPTION
**What this PR does / why we need it**:

ESP Home for making simple sensors and such out of ESP8266 and ESP32 devices. This can be bundled with Home Assistant but does not need to be. 