### PR TITLE
default smb loation for audiobooks as audiobook root

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -191,7 +191,7 @@ samba_shares:
     public: yes
     writable: yes
     browsable: yes
-    path: "{{ samba_shares_root }}/audiobooks"
+    path: "{{ audiobooks_root }}"
 
   - name: comics
     comment: 'Comics'


### PR DESCRIPTION

**What this PR does / why we need it**:

An unexpected default samba share location for audiobooks given that the rest of the media's default share locations are their defined root directories.
