### PR TITLE
Add RSS-Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Ansible config and a bunch of Docker containers.
 * [pyLoad](https://pyload.net/) - A download manager with a friendly web-interface
 * [PyTivo](http://pytivo.org) - An HMO and GoBack server for TiVos.
 * [Radarr](https://radarr.video/) - for organising and downloading movies
+* [RSS-Bridge](https://rss-bridge.github.io/rss-bridge/) - The RSS feed for websites missing it
 * [Sickchill](https://sickchill.github.io/) - for managing TV episodes
 * [Sonarr](https://sonarr.tv/) - for downloading and managing TV episodes
 * [Syncthing](https://syncthing.net/) - sync directories with another device

--- a/docs/applications/rssbridge.md
+++ b/docs/applications/rssbridge.md
@@ -1,0 +1,14 @@
+
+# RSS-Bridge
+
+Homepage: [https://rss-bridge.github.io/rss-bridge/](https://rss-bridge.github.io/rss-bridge/)
+
+RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one. It can be used on webservers or as a stand-alone application in CLI mode.
+
+Important: RSS-Bridge is not a feed reader or feed aggregator, but a tool to generate feeds that are consumed by feed readers and feed aggregators.
+
+## Usage
+
+Set `rssbridge_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The RSS-Bridge web interface can be found at http://ansible_nas_host_or_ip:8091.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -71,6 +71,7 @@ By default, applications can be found on the ports listed below.
 | PyTivo          | 9032    | Bridge  | HTTP           |
 | PyTivo          | 2190    | Bridge  | UDP            |
 | Radarr          | 7878    | Bridge  | HTTP           |
+| RSS-Bridge      | 8091    | Bridge  | HTTP           |
 | Sickchill       | 8081    | Bridge  | HTTP           |
 | Sonarr          | 8989    | Bridge  | HTTP           |
 | Syncthing admin | 8384    | Host    | HTTP           |

--- a/nas.yml
+++ b/nas.yml
@@ -268,6 +268,11 @@
         - radarr
       when: (radarr_enabled | default(False))
 
+    - role: rssbridge
+      tags:
+        - rssbridge
+      when: (rssbridge_enabled | default(False))
+
     - role: sickchill
       tags:
         - sickchill

--- a/roles/rssbridge/defaults/main.yml
+++ b/roles/rssbridge/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+rssbridge_enabled: false
+rssbridge_available_externally: "false"
+
+# directories
+rssbridge_data_directory: "{{ docker_home }}/rssbridge"
+
+
+# network
+rssbridge_port: "8091"
+rssbridge_hostname: "rssbridge"
+
+# specs
+rssbridge_memory: 1g

--- a/roles/rssbridge/tasks/main.yml
+++ b/roles/rssbridge/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: Create RSSBridge Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    # mode: 0755
+  with_items:
+    - "{{ rssbridge_data_directory }}/data"
+
+- name: RSSBridge Docker Container
+  docker_container:
+    name: rssbridge
+    image: rssbridge/rss-bridge
+    pull: true
+    volumes:
+      - "{{ rssbridge_data_directory }}/data:/config:rw"
+    ports:
+      - "{{ rssbridge_port }}:80"
+    restart_policy: unless-stopped
+    memory: "{{ rssbridge_memory }}"
+    labels:
+      traefik.enable: "{{ rssbridge_available_externally }}"
+      traefik.http.routers.rssbridge.rule: "Host(`{{ rssbridge_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.rssbridge.tls.certresolver: "letsencrypt"
+      traefik.http.routers.rssbridge.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.rssbridge.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.rssbridge.loadbalancer.server.port: "80"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:
Add [RSS-Bridge](https://rss-bridge.github.io/rss-bridge/).
From [their Github](https://github.com/RSS-Bridge/rss-bridge): 
RSS-Bridge is a PHP project capable of generating RSS and Atom feeds for websites that don't have one. It can be used on webservers or as a stand-alone application in CLI mode.

Important: RSS-Bridge is not a feed reader or feed aggregator, but a tool to generate feeds that are consumed by feed readers and feed aggregators.

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:
