### PR TITLE
Add Fresh RSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Ansible config and a bunch of Docker containers.
 * [Duplicati](https://www.duplicati.com/) - for backing up your stuff
 * [Emby](https://emby.media/) - Media streaming and management
 * [Firefly III](https://firefly-iii.org/) - Free and open source personal finance manager
+* [Fresh RSS](https://freshrss.org/) - Self-hosted RSS feed aggregator like Leed or Kriss Feed
 * [get_iplayer](https://github.com/get-iplayer/get_iplayer) - download programmes from BBC iplayer
 * [Gitea](https://gitea.io/en-us/) - Simple self-hosted GitHub clone
 * [GitLab](https://about.gitlab.com/features/) - Self-hosted GitHub clone of the highest order

--- a/docs/applications/freshrss.md
+++ b/docs/applications/freshrss.md
@@ -1,0 +1,22 @@
+
+# FreshRSS
+
+Homepage: [https://freshrss.org/](https://freshrss.org/)
+
+FreshRSS is a self-hosted RSS feed aggregator like Leed or Kriss Feed.
+
+It is lightweight, easy to work with, powerful, and customizable.
+
+It is a multi-user application with an anonymous reading mode. It supports custom tags. There is an API for (mobile) clients, and a Command-Line Interface.
+
+Thanks to the WebSub standard (formerly PubSubHubbub), FreshRSS is able to receive instant push notifications from compatible sources, such as Mastodon, Friendica, WordPress, Blogger, FeedBurner, etc.
+
+FreshRSS natively supports basic Web scraping, based on XPath, for Web sites not providing any RSS / Atom feed.
+
+Finally, it supports extensions for further tuning.
+
+## Usage
+
+Set `freshrss_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The FreshRSS web interface can be found at http://ansible_nas_host_or_ip:8089.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -19,6 +19,7 @@ By default, applications can be found on the ports listed below.
 | Emby            | 8096    | Bridge  | HTTP           |
 | Emby            | 8920    | Bridge  | HTTPS          |
 | Firefly III     | 8066    | Bridge  | HTTP           |
+| Fresh RSS       | 8089    | Bridge  | HTTP           |
 | get_iplayer     | 8182    | Bridge  | HTTP           |
 | Gitea           | 3001    | Bridge  | HTTP           |
 | Gitea           | 222     | Bridge  | SSH            |

--- a/nas.yml
+++ b/nas.yml
@@ -103,6 +103,11 @@
         - firefly
       when: (firefly_enabled | default(False))
 
+    - role: freshrss
+      tags:
+        - freshrss
+      when: (freshrss_enabled | default(False))
+
     - role: get_iplayer
       tags:
         - get_iplayer

--- a/roles/freshrss/defaults/main.yml
+++ b/roles/freshrss/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+freshrss_enabled: false
+freshrss_available_externally: "false"
+
+# directories
+freshrss_data_directory: "{{ docker_home }}/freshrss"
+freshrss_extensions_directory: "{{ docker_home }}/freshrss"
+
+
+# network
+freshrss_port: "8089"
+freshrss_hostname: "freshrss"
+
+# specs
+freshrss_memory: 1g

--- a/roles/freshrss/tasks/main.yml
+++ b/roles/freshrss/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Create FreshRSS Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    # mode: 0755
+  with_items:
+    - "{{ freshrss_data_directory }}/data"
+    - "{{ freshrss_extensions_directory }}/extensions"
+
+- name: FreshRSS Docker Container
+  docker_container:
+    name: freshrss
+    image: freshrss/freshrss
+    pull: true
+    volumes:
+      - "{{ freshrss_data_directory }}/data:/var/www/FreshRSS/data:rw"
+      - "{{ freshrss_extensions_directory }}/extensions:/var/www/FreshRSS/extensions:rw"
+    ports:
+      - "{{ freshrss_port }}:80"
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+      CRON_MIN: "1,31"
+    restart_policy: unless-stopped
+    memory: "{{ freshrss_memory }}"
+    labels:
+      traefik.enable: "{{ freshrss_available_externally }}"
+      traefik.http.routers.freshrss.rule: "Host(`{{ freshrss_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.freshrss.tls.certresolver: "letsencrypt"
+      traefik.http.routers.freshrss.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.freshrss.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.freshrss.loadbalancer.server.port: "80"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Add [FreshRSS](https://freshrss.org/).
From their [Github](https://github.com/FreshRSS/FreshRSS):
FreshRSS is a self-hosted RSS feed aggregator like Leed or Kriss Feed.
It is lightweight, easy to work with, powerful, and customizable.
It is a multi-user application with an anonymous reading mode. It supports custom tags. There is an API for (mobile) clients, and a Command-Line Interface.
Thanks to the WebSub standard (formerly PubSubHubbub), FreshRSS is able to receive instant push notifications from compatible sources, such as Mastodon, Friendica, WordPress, Blogger, FeedBurner, etc.
FreshRSS natively supports basic Web scraping, based on XPath, for Web sites not providing any RSS / Atom feed.
Finally, it supports extensions for further tuning.

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:
