### PR TITLE
Add Navidrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Ansible config and a bunch of Docker containers.
 * [Mylar](https://github.com/evilhero/mylar) - An automated Comic Book downloader (cbr/cbz) for use with SABnzbd, NZBGet and torrents
 * [MyMediaForAlexa](https://www.mymediaalexa.com/) - Lets you stream your music collection to your alexa device
 * [n8n](https://n8n.io/) - Nodemation, a node based workflow and automation service like IFTTT.
+* [navidrome](https://www.navidrome.org/) - Modern Music Server and Streamer compatible with Subsonic/Airsonic
 * [netboot.xyz](https://netboot.xyz/) - a PXE boot server
 * [Netdata](https://my-netdata.io/) - An extremely comprehensive system monitoring solution
 * [Nextcloud](https://nextcloud.com/) - A self-hosted Dropbox alternative

--- a/docs/applications/navidrome.md
+++ b/docs/applications/navidrome.md
@@ -1,0 +1,11 @@
+# Navidrome
+
+Homepage: [https://www.navidrome.org/](https://www.navidrome.org/)
+
+Navidrome is an open source web-based music collection server and streamer that is compatible with Subsonic/Airsonic. It gives you freedom to listen to your music collection from any browser or mobile device. It's like your personal Spotify!
+
+## Usage
+
+Set `navidrome_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The Navidrome web interface can be found at http://ansible_nas_host_or_ip:4533.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -50,6 +50,7 @@ By default, applications can be found on the ports listed below.
 | Mylar           | 8585    | Bridge  | HTTP           |
 | MyMediaForAlexa | 52051   | Host    | HTTP           |
 | n8n             | 5678    | Bridge  | HTTP           |
+| navidrome       | 4533    | Bridge  | HTTP           |
 | Netdata         | 19999   | Bridge  | HTTP           |
 | Nextcloud       | 8080    | Bridge  | HTTP           |
 | netbootxyz      | 3002    | Bridge  | HTTP           |

--- a/nas.yml
+++ b/nas.yml
@@ -198,6 +198,11 @@
         - n8n_enabled
       when: (n8n_enabled | default(False))
 
+    - role: navidrome
+      tags:
+        - navidrome
+      when: (navidrome_enabled | default(False))
+
     - role: netbootxyz
       tags:
         - netbootxyz

--- a/roles/navidrome/defaults/main.yml
+++ b/roles/navidrome/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+navidrome_enabled: false
+navidrome_available_externally: "false"
+
+# directories
+navidrome_data_directory: "{{ docker_home }}/navidrome"
+navidrome_music_directory: "{{ music_root }}"
+
+
+# network
+navidrome_port: "4533"
+navidrome_hostname: "navidrome"
+
+# specs
+navidrome_memory: 1g
+
+# default config
+navidrome_scan_schedule: "@every 1m" # Cron syntax (https://en.wikipedia.org/wiki/Cron)
+navidrome_log_level: "info"
+navidrome_session_timeout: "24h"

--- a/roles/navidrome/tasks/main.yml
+++ b/roles/navidrome/tasks/main.yml
@@ -1,0 +1,35 @@
+---
+- name: Create Navidrome Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    # mode: 0755
+  with_items:
+    - "{{ navidrome_data_directory }}/data"
+    - "{{ navidrome_data_directory }}/playlists"
+
+- name: Navidrome Docker Container
+  docker_container:
+    name: navidrome
+    image: deluan/navidrome:latest
+    pull: true
+    volumes:
+      - "{{ navidrome_data_directory }}/data:/navidrome/data:rw"
+      - "{{ navidrome_music_directory }}:/navidrome/music:rw"
+    ports:
+      - "{{ navidrome_port }}:4533"
+    env:
+      ND_MUSICFOLDER: "/navidrome/music"
+      ND_DATAFOLDER: "/navidrome/data"
+      ND_SCANSCHEDULE: "{{ navidrome_scan_schedule }}"
+      ND_LOGLEVEL: "{{ navidrome_log_level }}"
+      ND_SESSIONTIMEOUT: "{{ navidrome_session_timeout }}"
+    restart_policy: unless-stopped
+    memory: "{{ navidrome_memory }}"
+    labels:
+      traefik.enable: "{{ navidrome_available_externally }}"
+      traefik.http.routers.navidrome.rule: "Host(`{{ navidrome_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.navidrome.tls.certresolver: "letsencrypt"
+      traefik.http.routers.navidrome.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.navidrome.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.navidrome.loadbalancer.server.port: "4533"


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Add [Navidrome](https://www.navidrome.org/)
From their [Github](https://github.com/navidrome/navidrome):
Navidrome is an open source web-based music collection server and streamer that is compatible with Subsonic/Airsonic. It gives you freedom to listen to your music collection from any browser or mobile device. It's like your personal Spotify!

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:

Thank you for making this repo!