### PR TITLE
Added healthchecks.io service integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ If you have a spare domain name you can configure applications to be accessible 
 * [Gotify](https://gotify.net/) Self-hosted server for sending push notifications
 * [Grafana](https://github.com/grafana/grafana) - Dashboarding tool
 * [Guacamole](https://guacamole.apache.org/) - Web based remote desktop gateway, supports VNC, RDP and SSH
+* [healthchecks.io](https://healthchecks.io/) - Ensure your NAS is online and get notified otherwise
 * [Heimdall](https://heimdall.site/) - Home server dashboard
 * [Home Assistant](https://www.home-assistant.io) - Open source home automation
 * [InfluxDB](https://github.com/influxdata/influxdb) - Time series database used for stats collection

--- a/docs/applications/healthchecks.io.md
+++ b/docs/applications/healthchecks.io.md
@@ -1,0 +1,11 @@
+# Healthchecks.io
+
+Homepage: [https://healthchecks.io/](https://healthchecks.io/)
+
+A simple cronjob that uses `curl` to ping a given endpoint on the `healthchecks.io` servers. You can choose how often it should ping the endpoint, and what happens when it doesn't. Email/Slack/Telegram and many more services can be integrated.
+
+## Usage
+
+Create your own project on [https://healthchecks.io/](https://healthchecks.io/), and set both the time between pings and the grace time. Set your prefered integration such as email.
+
+Set `healthchecks_enabled: true` in your `inventories/<your_inventory>/nas.yml` file, and if your time between pings is different than the default `healthchecks_ping_minutes`, change it. Finally, set your ping url in the `healthchecks_url` variable.

--- a/nas.yml
+++ b/nas.yml
@@ -6,7 +6,6 @@
       tags: users
 
   roles:
-
     ###
     ### Requirements
     ###
@@ -25,7 +24,6 @@
         - docker
         - skip_ansible_lint
 
-
     ###
     ### Ansible-NAS Roles
     ###
@@ -38,7 +36,6 @@
       tags:
         - ansible-nas-docker
         - ansible-nas
-
 
     ###
     ### Applications
@@ -147,6 +144,11 @@
       tags:
         - gotify
       when: (gotify_enabled | default(False))
+
+    - role: healthchecks.io
+      tags:
+        - healthchecks.io
+      when: (healthchecks_enabled | default(False))
 
     - role: heimdall
       tags:

--- a/roles/healthchecks.io/defaults/main.yml
+++ b/roles/healthchecks.io/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+healthchecks_enabled: false
+healthchecks_ping_minutes: 15
+
+healthchecks_url: ""

--- a/roles/healthchecks.io/tasks/main.yml
+++ b/roles/healthchecks.io/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Add healthchecks.io cronjob
+  cron:
+    name: healthchecks.io
+    minute: "*/{{ healthchecks_ping_minutes }}"
+    user: root
+    cron_file: /etc/crontab
+    job: "curl -m 10 --retry 5 {{ healthchecks_url }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
Integrates a cronjob for sending pings to the [healthchecks.io](https://healthchecks.io) servers, allowing the user to ensure its NAS is online. If not, various integrations can be set for alerting the user