### PR TITLE
:sparkles: added cloudflared service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you have a spare domain name you can configure applications to be accessible 
 * [Booksonic](https://booksonic.org/) - The selfhosted audiobook server
 * [Calibre-web](https://github.com/janeczku/calibre-web) - Provides a clean interface for browsing, reading and downloading eBooks using an existing Calibre database.
 * [Cloud Commander](https://cloudcmd.io/) - A dual panel file manager with integrated web console and text editor
+* [Cloudflared (Argo tunnel)](https://github.com/cloudflare/cloudflared) - Bypass Carrier Grade NAT (CGNAT) restrictions by serving your services through a direct Cloudflare connection
 * [Cloudflare DDNS](https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/) - automatically update Cloudflare with your IP address
 * [CouchPotato](https://couchpota.to/) - for downloading and managing movies
 * [Deluge](https://dev.deluge-torrent.org/) - A lightweight, Free Software, cross-platform BitTorrent client.

--- a/docs/applications/cloudflared.md
+++ b/docs/applications/cloudflared.md
@@ -1,0 +1,27 @@
+# Cloudflared (Argo tunnel)
+
+Homepage: [https://github.com/cloudflare/cloudflared](https://github.com/cloudflare/cloudflared)
+
+Cloudflare Argo tunnel: [https://blog.cloudflare.com/argo-tunnel/](https://blog.cloudflare.com/argo-tunnel/)
+
+Cloudflare: [https://www.cloudflare.com](https://www.cloudflare.com)
+
+This service is very useful when your NAS doesn't have a static IP and it's situated a [Carrier Grade NAT](https://en.wikipedia.org/wiki/Carrier-grade_NAT). With this approach your NAS is connected directly to the Cloudflare servers, which allow public access to your externally available applications.
+
+## Usage
+
+Set `cloudflared_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+Set `cloudflared_token` to the one you grab from the Cloudflare Zero Trust Dashboard (more below).
+
+## Specific Configuration
+
+Create a cloudflare account if you don't have one. You will need to purchase a domain name registered with Cloudflare, or migrate an existing one on the platform.
+
+On your cloudflare account page, navigate to the Zero Trust dashboard, and create a Tunnel in the Access/Tunnels menu.
+
+After choosing a name for your tunnel, in the environment section choose Docker, and take note of the token in the code section below (the long string after the `--token` command): this will be your `cloudflared_token`.
+
+In the next page (public hostname) you will need to set some values, which we will delete later: set your domain as your cloudflare hostname, Service as `HTTPS` and `localhost`, then save the changes. Edit the Catch-all-rule to be `https://localhost:443`, then delete the entry you made one step before. Your Cloudflare tunnel will now redirect all incoming requests to your Traefik service runnin on port 443, which will route them accordingly.
+
+Now your chosen services are exposed to the internet (the ones that have the `*_available_externally` variable set to `true`).

--- a/nas.yml
+++ b/nas.yml
@@ -6,7 +6,6 @@
       tags: users
 
   roles:
-
     ###
     ### Requirements
     ###
@@ -25,7 +24,6 @@
         - docker
         - skip_ansible_lint
 
-
     ###
     ### Ansible-NAS Roles
     ###
@@ -38,7 +36,6 @@
       tags:
         - ansible-nas-docker
         - ansible-nas
-
 
     ###
     ### Applications
@@ -67,6 +64,11 @@
       tags:
         - cloudcmd
       when: (cloudcmd_enabled | default(False))
+
+    - role: cloudflared
+      tags:
+        - cloudflared
+      when: (cloudflared_enabled | default(False))
 
     - role: cloudflare_ddns
       tags:

--- a/roles/cloudflared/defaults/main.yml
+++ b/roles/cloudflared/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+cloudflared_enabled: false
+
+cloudflared_token: ""

--- a/roles/cloudflared/tasks/main.yml
+++ b/roles/cloudflared/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Cloudflared Docker Container
+  docker_container:
+    name: cloudflared
+    image: cloudflare/cloudflared
+    pull: true
+    env:
+      TZ: "{{ ansible_nas_timezone }}"
+    restart_policy: unless-stopped
+    command: "tunnel --no-autoupdate run --token {{ cloudflared_token }}"
+    network_mode: "host"
+    recreate: true


### PR DESCRIPTION
**What this PR does / why we need it**: Adds Cloudflare Argo tunnel support through cloudflared, very useful when a user is behind a Carrier Grade NAT (often the case when using a SIM card for internet connection)


**Which issue (if any) this PR fixes**:

Fixes #522 