### PR TITLE
Fixed issue when octoprint_enable_webcam is false but  ENABLE_MJPG_STREAMER is still set to true

### DIFF
--- a/roles/octoprint/tasks/main.yml
+++ b/roles/octoprint/tasks/main.yml
@@ -23,7 +23,7 @@
     env:
       TZ: "{{ ansible_nas_timezone }}"
       MJPG_STREAMER_INPUT: "-n -r 1080x1024 -f 30"
-      ENABLE_MJPG_STREAMER: "true"
+      ENABLE_MJPG_STREAMER: "{{ octoprint_enable_webcam | string }}"
     labels:
       traefik.enable: "{{ octoprint_available_externally | string }}"
       traefik.http.routers.octoprint.rule: "Host(`{{ octoprint_hostname }}.{{ ansible_nas_domain }}`)"


### PR DESCRIPTION
fixes a startup issue for the octoprint application, since `ENABLE_MJPG_STREAMER` was always set to `true` regardless of the `octoprint_enable_webcam` variable