### PR TITLE
Added postfix gmail relay

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If you have a spare domain name you can configure applications to be accessible 
 * [Piwigo](https://piwigo.org/) - Photo Gallery Software
 * [Plex](https://www.plex.tv/) - Plex Media Server
 * [Portainer](https://portainer.io/) - for managing Docker and running custom images
+* [Postfix Gmail relay](https://www.postfix.org/) - Setup Postfix as a Gmail relay and send emails whenever you want
 * [Prowlarr](https://github.com/Prowlarr/Prowlarr) - Indexer aggregator for Sonarr, Radarr, Lidarr, etc.
 * [pyLoad](https://pyload.net/) - A download manager with a friendly web-interface
 * [PyTivo](http://pytivo.org) - An HMO and GoBack server for TiVos.

--- a/docs/applications/postfix_gmail_relay.md
+++ b/docs/applications/postfix_gmail_relay.md
@@ -1,0 +1,15 @@
+# Postfix Gmail relay
+
+Homepage: [Postfix](https://www.postfix.org/)
+
+Make your NAS able to send emails using your email, by setting up Postfix with Gmail. Particularly useful if you also want to set up alerts for zpool scrubs, SMART error monitoring, or backup issues. The emails sent from your NAS will use the address specified `postfix_gmail_relay_email`, which by default is equal to `ansible_nas_email`. Make sure `postfix_gmail_relay_email` is a Gmail account, which you need to have access to.
+
+## Usage
+
+Update your inventory in `inventories/<your_inventory>/group_vars/nas.yml` with the following:
+
+- `postfix_gmail_relay_enabled: true`
+- `postfix_gmail_relay_email` if different from `ansible_nas_email`
+- `postfix_gmail_relay_app_password`: create an app password in your Google account, by opening the Security tab followed by App passwords. In `Select app` choose `Other (Custom name)` and set any name you want, like `Postfix Ansible NAS`. Set the variable to the password shown
+
+Run the ansible playbook task for postfix (`ansible-playbook -i inventories/<your_inventory>/inventory nas.yml -b -K -t postfix`), then try to send yourself an email using `echo "Test mail from Ansible NAS" | mail -s "Test Postfix" your_email`

--- a/nas.yml
+++ b/nas.yml
@@ -265,6 +265,11 @@
         - portainer
       when: (portainer_enabled | default(False))
 
+    - role: postfix
+      tags:
+        - postfix
+      when: (postfix_enabled | default(False))
+
     - role: prowlarr
       tags:
         - prowlarr

--- a/roles/postfix-gmail-relay/defaults/main.yml
+++ b/roles/postfix-gmail-relay/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+postfix_gmail_relay_enabled: false
+
+postfix_gmail_relay_email: "{{ ansible_nas_email }}"
+postfix_gmail_relay_app_password: ""

--- a/roles/postfix-gmail-relay/tasks/main.yml
+++ b/roles/postfix-gmail-relay/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Install postfix package
+  apt:
+    name: "postfix"
+    state: present
+  register: result
+  until: result is succeeded
+
+- name: Enable and start postfix service
+  service:
+    name: "postfix"
+    state: started
+    enabled: true
+
+- name: Add required lines in /etc/postfix/main.cf file
+  template:
+    src: templates/postfix/main.cf.j2
+    dest: /etc/postfix/main.cf
+
+- name: Configure postfix sasl creds
+  copy:
+    content: "[smtp.gmail.com]:587 {{ postfix_gmail_relay_email }}:{{ postfix_gmail_app_password }}"
+    dest: /etc/postfix/sasl_passwd
+    owner: root
+    group: postfix
+    mode: 0640
+
+- name: Process password file
+  command: postmap /etc/postfix/sasl_passwd
+
+- name: Enable and start postfix service
+  service:
+    name: "postfix"
+    state: restarted

--- a/templates/postfix/main.cf.j2
+++ b/templates/postfix/main.cf.j2
@@ -1,0 +1,8 @@
+myhostname = {{ ansible_nas_domain }}
+
+relayhost = [smtp.gmail.com]:587
+smtp_use_tls = yes
+smtp_sasl_auth_enable = yes
+smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
+smtp_sasl_security_options =


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets up postfix using a Gmail app password, allowing the NAS to send emails using the `mail` command. Very useful for:
- sending alerts for zpool scrubs outcomes
- sending errors for failed SMART checks on drives
- sending alerts for backup outcomes/failures (e.g. when using Duplicati)

Tested on both x86_64 and arm64 architectures, no issues emerged.

I would plan on adding some documentation on how to set up some of the above usecases in the `zfs_configuration.md` file or similar (since I use this setup for the cases above), let me know :)