### PR TITLE
FIX & FEATURE ADD: YouTubeDL-Material  - remove unnecessary directories and add ability to…

### DIFF
--- a/roles/youtubedlmaterial/tasks/main.yml
+++ b/roles/youtubedlmaterial/tasks/main.yml
@@ -6,9 +6,6 @@
     # mode: 0755
   with_items:
     - "{{ youtubedlmaterial_data_directory }}/appdata"
-    - "{{ youtubedlmaterial_data_directory }}/audio"
-    - "{{ youtubedlmaterial_data_directory }}/video"
-    - "{{ youtubedlmaterial_data_directory }}/subscriptions"
     - "{{ youtubedlmaterial_dl_audio_directory }}"
     - "{{ youtubedlmaterial_dl_video_directory }}"
     - "{{ youtubedlmaterial_dl_subscriptions_directory }}"
@@ -23,6 +20,7 @@
       - "{{ youtubedlmaterial_dl_audio_directory }}:/app/audio:rw"
       - "{{ youtubedlmaterial_dl_video_directory }}:/app/video:rw"
       - "{{ youtubedlmaterial_dl_subscriptions_directory }}:/app/subscriptions:rw"
+      - "{{ podcasts_root }}:/app/podcasts:rw"
     network_mode: "bridge"
     ports:
       - "{{ youtubedlmaterial_port_http }}:17442"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

FIX: - removed /audio, /video, /subscriptions directories creation in docker_home/youtubedlmaterial as they are not used
FEATURE: - added volume to allow saving subscriptions to podcasts_root


**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
