### PR TITLE
FEATURE ADD: Nextcloud - change images to variables

### DIFF
--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -5,6 +5,10 @@ nextcloud_available_externally: false
 # directories
 nextcloud_data_directory: "{{ docker_home }}/nextcloud"
 
+# images
+nextcloud_image: "nextcloud:14"
+nextcloud_mysql_image: "mysql:5.7"
+
 # network
 nextcloud_port: "8080"
 nextcloud_hostname: "nextcloud"

--- a/roles/nextcloud/tasks/main.yml
+++ b/roles/nextcloud/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Nextcloud Mysql Docker Container
   docker_container:
     name: nextcloud-mysql
-    image: mysql:5.7
+    image: "{{ nextcloud_mysql_image }}"
     pull: true
     volumes:
       - "{{ nextcloud_data_directory }}/mysql:/var/lib/mysql:rw"
@@ -25,7 +25,7 @@
 - name: Nextcloud Docker Container
   docker_container:
     name: nextcloud
-    image: nextcloud:14
+    image: "{{ nextcloud_image }}"
     pull: true
     links:
       - nextcloud-mysql:mysql


### PR DESCRIPTION
- create image variables so that users can define/overwrite the defaults

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Allow users to choose what images (versions basically) to use for NextCloud. Current default is 14 which is 10 major versions behind the current version. For compatibility sake to OG users the default can remain at v14 and they can then override this when they choose to upgrade. It's recommended that NEW ansible-nas users override the defaults and use the current versions. (Maybe this should be a comment with the variables...hmmmm)


**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

I know this has been brought up in the past but for whatever reason it hasn't been done. (Maybe because there were other changes that were incorporated at the same time that didn't pass the mustard?) So I figured let's make this simple and get it done.