### PR TITLE
FIX: duplicati - allow restore of docker persistent data

### DIFF
--- a/roles/duplicati/tasks/main.yml
+++ b/roles/duplicati/tasks/main.yml
@@ -16,7 +16,7 @@
     volumes:
       - "{{ duplicati_data_directory }}:/config:rw"
       - "{{ samba_shares_root }}:/source/shares:{{ duplicati_data_permissions }}"
-      - "{{ docker_home }}:/source/docker:ro"
+      - "{{ docker_home }}:/source/docker:{{ duplicati_data_permissions }}"
       - "/etc/timezone:/etc/timezone:ro"
     env:
       TZ: "{{ ansible_nas_timezone }}"


### PR DESCRIPTION
- adds ability to restore to docker_home when duplicati_data_permissions is overridden to "rw"

NOTE: I'm not sure why this wasn't addressed in https://github.com/davestephens/ansible-nas/pull/204. I addressed it with a question in https://github.com/davestephens/ansible-nas/issues/171 but never received a response. Hopefully this is a desirable enhancement allowing direct restoring of Docker containers' persistent data without having to restore to a temp area and then move it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:



**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
