### PR TITLE
ADD: scrutiny - Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ If you have a spare domain name you can configure applications to be accessible 
 * [Route53 DDNS](https://crazymax.dev/ddns-route53/) - Automatically update AWS Route53 with your IP address
 * [RSS-Bridge](https://rss-bridge.github.io/rss-bridge/) - The RSS feed for websites missing it
 * [Sabnzbd](https://sabnzbd.org/) - A powerful usenet downloader that FreeNAS provides
+* [scrutiny](https://github.com/AnalogJ/scrutiny) - Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds
 * [Sickchill](https://sickchill.github.io/) - for managing TV episodes
 * [Sonarr](https://sonarr.tv/) - for downloading and managing TV episodes
 * [Speedtest-Tracker](https://github.com/henrywhitaker3/Speedtest-Tracker) - Continuously track your internet speed

--- a/docs/applications/scrutiny.md
+++ b/docs/applications/scrutiny.md
@@ -14,21 +14,19 @@ The scrutiny web interface can be found at <http://ansible_nas_host_or_ip:8086>.
 
 To enable more disks to be scrutinized than just sda you'll need to edit your `inventories/<your_inventory>/nas.yml` file and add an override for the devices the scrutiny container can see. Example:
 
-```
-scrutiny_devices:
- - /dev/sda:/dev/sda
- - /dev/sdb:/dev/sdb
- - /dev/sdc:/dev/sdc
- - /dev/sdd:/dev/sdd
- - /dev/sde:/dev/sde
- - /dev/sdf:/dev/sdf
- - /dev/sdg:/dev/sdg
- - /dev/sdh:/dev/sdh
- - /dev/sdi:/dev/sdi
- - /dev/sdj:/dev/sdj
- - /dev/sdk:/dev/sdk
- - /dev/sdl:/dev/sdl
- - /dev/sdm:/dev/sdm
- - /dev/sdn:/dev/sdn
- - /dev/nvme0n1:/dev/nvme0n1
-```
+`scrutiny_devices:`  
+` - /dev/sda:/dev/sda`   
+` - /dev/sdb:/dev/sdb`   
+` - /dev/sdc:/dev/sdc`   
+` - /dev/sdd:/dev/sdd`  
+` - /dev/sde:/dev/sde`  
+` - /dev/sdf:/dev/sdf`  
+` - /dev/sdg:/dev/sdg`  
+` - /dev/sdh:/dev/sdh`  
+` - /dev/sdi:/dev/sdi`  
+` - /dev/sdj:/dev/sdj`  
+` - /dev/sdk:/dev/sdk`  
+` - /dev/sdl:/dev/sdl`  
+` - /dev/sdm:/dev/sdm`  
+` - /dev/sdn:/dev/sdn`  
+` - /dev/nvme0n1:/dev/nvme0n1`  

--- a/docs/applications/scrutiny.md
+++ b/docs/applications/scrutiny.md
@@ -9,3 +9,26 @@ scrutiny is a Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Fa
 Set `scrutiny_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
 
 The scrutiny web interface can be found at <http://ansible_nas_host_or_ip:8086>.
+
+## Specific Configuration
+
+To enable more disks to be scrutinized than just sda you'll need to edit your `inventories/<your_inventory>/nas.yml` file and add an override for the devices the scrutiny container can see. Example:
+
+```
+scrutiny_devices:
+ - /dev/sda:/dev/sda
+ - /dev/sdb:/dev/sdb
+ - /dev/sdc:/dev/sdc
+ - /dev/sdd:/dev/sdd
+ - /dev/sde:/dev/sde
+ - /dev/sdf:/dev/sdf
+ - /dev/sdg:/dev/sdg
+ - /dev/sdh:/dev/sdh
+ - /dev/sdi:/dev/sdi
+ - /dev/sdj:/dev/sdj
+ - /dev/sdk:/dev/sdk
+ - /dev/sdl:/dev/sdl
+ - /dev/sdm:/dev/sdm
+ - /dev/sdn:/dev/sdn
+ - /dev/nvme0n1:/dev/nvme0n1
+```

--- a/docs/applications/scrutiny.md
+++ b/docs/applications/scrutiny.md
@@ -14,19 +14,21 @@ The scrutiny web interface can be found at <http://ansible_nas_host_or_ip:8086>.
 
 To enable more disks to be scrutinized than just sda you'll need to edit your `inventories/<your_inventory>/nas.yml` file and add an override for the devices the scrutiny container can see. Example:
 
-`scrutiny_devices:`  
-` - /dev/sda:/dev/sda`   
-` - /dev/sdb:/dev/sdb`   
-` - /dev/sdc:/dev/sdc`   
-` - /dev/sdd:/dev/sdd`  
-` - /dev/sde:/dev/sde`  
-` - /dev/sdf:/dev/sdf`  
-` - /dev/sdg:/dev/sdg`  
-` - /dev/sdh:/dev/sdh`  
-` - /dev/sdi:/dev/sdi`  
-` - /dev/sdj:/dev/sdj`  
-` - /dev/sdk:/dev/sdk`  
-` - /dev/sdl:/dev/sdl`  
-` - /dev/sdm:/dev/sdm`  
-` - /dev/sdn:/dev/sdn`  
-` - /dev/nvme0n1:/dev/nvme0n1`  
+```ansible
+scrutiny_devices:
+ - /dev/sda:/dev/sda
+ - /dev/sdb:/dev/sdb
+ - /dev/sdc:/dev/sdc
+ - /dev/sdd:/dev/sdd
+ - /dev/sde:/dev/sde
+ - /dev/sdf:/dev/sdf
+ - /dev/sdg:/dev/sdg
+ - /dev/sdh:/dev/sdh
+ - /dev/sdi:/dev/sdi
+ - /dev/sdj:/dev/sdj
+ - /dev/sdk:/dev/sdk
+ - /dev/sdl:/dev/sdl
+ - /dev/sdm:/dev/sdm
+ - /dev/sdn:/dev/sdn
+ - /dev/nvme0n1:/dev/nvme0n1
+```

--- a/docs/applications/scrutiny.md
+++ b/docs/applications/scrutiny.md
@@ -1,0 +1,11 @@
+# scrutiny
+
+Homepage: <https://github.com/AnalogJ/scrutiny/>
+
+scrutiny is a Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds.
+
+## Usage
+
+Set `scrutiny_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The scrutiny web interface can be found at <http://ansible_nas_host_or_ip:8086>.

--- a/docs/configuration/application_ports.md
+++ b/docs/configuration/application_ports.md
@@ -81,6 +81,7 @@ By default, applications can be found on the ports listed below.
 | Radarr           | 7878    | Bridge  | HTTP           |
 | RSS-Bridge       | 8091    | Bridge  | HTTP           |
 | Sabnzbd          | 18080   | Bridge  | HTTP           |
+| scrutiny         | 8085    | Bridge  | HTTP           |
 | Sickchill        | 8081    | Bridge  | HTTP           |
 | Sonarr           | 8989    | Bridge  | HTTP           |
 | Speedtest-Trk    | 8765    | HTTP    |                |

--- a/nas.yml
+++ b/nas.yml
@@ -305,6 +305,11 @@
         - sabnzbd
       when: (sabnzbd_enabled | default(False))
 
+    - role: scrutiny
+      tags:
+        - scrutiny
+      when: (scrutiny_enabled | default(False))
+
     - role: route53_ddns
       tags:
         - route53_ddns

--- a/roles/scrutiny/defaults/main.yml
+++ b/roles/scrutiny/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# enable or disable the application
+scrutiny_enabled: false
+scrutiny_available_externally: false
+
+# directories
+scrutiny_data_directory: "{{ docker_home }}/scrutiny"
+
+# uid / gid
+scrutiny_user_id: "0"
+scrutiny_group_id: "0"
+
+# network
+scrutiny_hostname: "scrutiny"
+scrutiny_port: "8085"
+scrutiny_influxdb_port: "8086"
+
+# specs
+scrutiny_memory: "256m"

--- a/roles/scrutiny/defaults/main.yml
+++ b/roles/scrutiny/defaults/main.yml
@@ -17,3 +17,7 @@ scrutiny_influxdb_port: "8086"
 
 # specs
 scrutiny_memory: "256m"
+
+# disks
+scrutiny_devices:
+ - /dev/sda:/dev/sda

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ scrutiny_data_directory }}/config"
     - "{{ scrutiny_data_directory }}/influxdb"
 
-- name: Create Scrutiny Container
+- name: Create Scrutiny Docker Container
   docker_container:
     name: scrutiny
     image: ghcr.io/analogj/scrutiny:master-omnibus

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -20,8 +20,7 @@
       - "/run/udev:/run/udev:ro"
     ports:
       - "{{ scrutiny_port }}: 8080"
-    devices:                             # herein lies the problem!
-      - /dev/sda:/dev/sda
+    devices: "{{ scrutiny_devices }}"
     capabilities:
       - SYS_RAWIO
       - SYS_ADMIN

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -7,7 +7,7 @@
     - "{{ scrutiny_data_directory }}"
     - "{{ scrutiny_data_directory }}/config"
     - "{{ scrutiny_data_directory }}/influxdb"
-    
+
 - name: Create Scrutiny Container
   docker_container:
     name: scrutiny

--- a/roles/scrutiny/tasks/main.yml
+++ b/roles/scrutiny/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Create Scrutiny Directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+    - "{{ scrutiny_data_directory }}"
+    - "{{ scrutiny_data_directory }}/config"
+    - "{{ scrutiny_data_directory }}/influxdb"
+    
+- name: Create Scrutiny Container
+  docker_container:
+    name: scrutiny
+    image: ghcr.io/analogj/scrutiny:master-omnibus
+    pull: true
+    env:
+    volumes:
+      - "{{ scrutiny_data_directory }}/config:/opt/scrutiny/config"
+      - "{{ scrutiny_data_directory }}/influxdb:/opt/scrutiny/influxdb"
+      - "/run/udev:/run/udev:ro"
+    ports:
+      - "{{ scrutiny_port }}: 8080"
+    devices:                             # herein lies the problem!
+      - /dev/sda:/dev/sda
+    capabilities:
+      - SYS_RAWIO
+      - SYS_ADMIN
+    restart_policy: unless-stopped
+    memory: "{{ scrutiny_memory }}"
+    labels:
+      traefik.enable: "{{ scrutiny_available_externally | string }}"
+      traefik.http.routers.scrutiny.rule: "Host(`{{ scrutiny_hostname }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.scrutiny.tls.certresolver: "letsencrypt"
+      traefik.http.routers.scrutiny.tls.domains[0].main: "{{ ansible_nas_domain }}"
+      traefik.http.routers.scrutiny.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+      traefik.http.services.scrutiny.loadbalancer.server.port: "8080"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

**NOTE: This is a work in progress and help is requested to overcome a configuration obstacle.**

Adds scrutiny - Hard Drive S.M.A.R.T Monitoring, Historical Trends & Real World Failure Thresholds


**Which issue (if any) this PR fixes**: https://github.com/davestephens/ansible-nas/issues/2 from the very early days of AN!

Fixes #

**Any other useful info**:

This scrutiny addition has a problem to overcome that I'm not technically proficient enough at the moment to solve. I'm requesting help to get this finished. The problem is the list of devices (disks) will be different for different users. Thus the devices can't statically be assigned, with the possible exception of sda, in the task file. Asking users to edit the task file is out of the question as it would just be overwritten on their next git pull. So the disk device list needs to be created dynamically at runtime. Ansible facts can supply the info. A little Googlefu and I can get the info, but I (repeat) am not technically proficient enough at Ansible to process the info arrays and use it. So hopefully someone good at that stuff can help finish this.

This gets and displays the needed info, but that's as far as I got.
```
################################ TESTING ########################################
- name: Output SATA disks
  debug:
    var: hostvars[inventory_hostname].ansible_devices.keys() | map('regex_search', 'sd.*') | select('string') | list

- name: Output NVME disks
  debug:
    var: hostvars[inventory_hostname].ansible_devices.keys() | map('regex_search', 'nvme.*') | select('string') | list
################################ TESTING ########################################
```
