### PR TITLE
Removed cron_file command from cron task

### DIFF
--- a/roles/healthchecks.io/tasks/main.yml
+++ b/roles/healthchecks.io/tasks/main.yml
@@ -4,5 +4,4 @@
     name: healthchecks.io
     minute: "*/{{ healthchecks_ping_minutes }}"
     user: root
-    cron_file: /etc/crontab
     job: "curl -m 10 --retry 5 {{ healthchecks_url }}"


### PR DESCRIPTION
After installing ansible-nas on a fresh system I noticed that the healthchecks.io task was failing, even though it was working before. The error message mentions that ansible won't edit cronjobs through the `/etc/crontab` file.

 It could be due to using a newer ubuntu version (22.04) or an updated ansible package, the fix is as easy as removing the `cron_file` command in the cron task