### PR TITLE
FIX: Speedtest-Tracker - correct container name

### DIFF
--- a/roles/speedtest-tracker/tasks/main.yml
+++ b/roles/speedtest-tracker/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Speedtest-Tracker Docker Container
   docker_container:
-    name: speedtest_tracker
+    name: speedtest-tracker
     image: henrywhitaker3/speedtest-tracker:latest
     pull: true
     volumes:

--- a/roles/speedtest-tracker/tasks/main.yml
+++ b/roles/speedtest-tracker/tasks/main.yml
@@ -10,7 +10,7 @@
   docker_container:
     name: speedtest_tracker
     state: absent
-  when: speedtest_tracker_enabled = true
+  when: speedtest_tracker_enabled == true
 
 - name: Speedtest-Tracker Docker Container
   docker_container:

--- a/roles/speedtest-tracker/tasks/main.yml
+++ b/roles/speedtest-tracker/tasks/main.yml
@@ -10,8 +10,7 @@
   docker_container:
     name: speedtest_tracker
     state: absent
-  when: speedtest_tracker_enabled == true
-
+  
 - name: Speedtest-Tracker Docker Container
   docker_container:
     name: speedtest-tracker

--- a/roles/speedtest-tracker/tasks/main.yml
+++ b/roles/speedtest-tracker/tasks/main.yml
@@ -10,7 +10,7 @@
   docker_container:
     name: speedtest_tracker
     state: absent
-  
+
 - name: Speedtest-Tracker Docker Container
   docker_container:
     name: speedtest-tracker

--- a/roles/speedtest-tracker/tasks/main.yml
+++ b/roles/speedtest-tracker/tasks/main.yml
@@ -6,6 +6,12 @@
   with_items:
     - "{{ speedtest_data_directory }}/config"
 
+- name: Remove old Speedtest-Tracker Docker Container
+  docker_container:
+    name: speedtest_tracker
+    state: absent
+  when: speedtest_tracker_enabled = true
+
 - name: Speedtest-Tracker Docker Container
   docker_container:
     name: speedtest-tracker


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Fixes the Speedtest-Tracker container name from speedtest_tracker to speedtest-tracker

Yes, it's minor, but it's proper.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

This will cause a bind failure if the container is already running as speedtest_tracker. I am willing to add code to remove (state : absent) the original container if you so desire.
