### PR TITLE
FEATURE ADDITION: Ansible NAS Plugins

### DIFF
--- a/docs/applications/plugins.md
+++ b/docs/applications/plugins.md
@@ -1,0 +1,13 @@
+# plugins
+
+Ansible NAS supports custom plugins created specifically for Ansible NAS by independent developers.
+
+## Usage
+
+Set `plugins_enabled: true` in your `inventories/<your_inventory>/nas.yml` file to enable the plugins feature.
+
+## Specific Configuration
+
+Enabling a plugin can be as easy as setting `<plugin_name>_enabled: true` in your `inventories/<your_inventory>/nas.yml` file, but every plugin is different. You will need to read the plugin's documentation to find out any other configuration options.
+
+**NOTE:** Ansible NAS plugins are created by independent developers and are not endorsed, sponsored, or supported in any way by the author of Ansible NAS. Please contact the plugin's developer for any and all support.

--- a/nas.yml
+++ b/nas.yml
@@ -380,6 +380,11 @@
         - znc
       when: (znc_enabled | default(False))
 
+    - role: ansible-nas-plugins
+      tags:
+        - plugins
+      when: (plugins_enabled | default(False))
+
   tasks:
     - import_tasks: tasks/thelounge.yml
       when: (thelounge_enabled | default(False))

--- a/plugins/sample.yml
+++ b/plugins/sample.yml
@@ -1,0 +1,16 @@
+---
+  - debug:
+      msg:
+        - "Running unsupported Ansible NAS plugins."
+        - "WARNING: Use at your own risk."
+
+# templates below:
+####  how do roles know their file locations? - will role: plugins/role/appname work?
+#    - role: appname
+#      tags:
+#        - appname
+#      when: (appname_enabled | default(False))
+
+#    - import_tasks: plugins/tasks/appname.yml
+#      when: (appname_enabled | default(False))
+#      tags: appname

--- a/plugins/sample.yml
+++ b/plugins/sample.yml
@@ -5,12 +5,12 @@
         - "WARNING: Use at your own risk."
 
 # templates below:
-####  how do roles know their file locations? - will role: plugins/role/appname work?
-#    - role: appname
-#      tags:
-#        - appname
-#      when: (appname_enabled | default(False))
-
-#    - import_tasks: plugins/tasks/appname.yml
-#      when: (appname_enabled | default(False))
-#      tags: appname
+#
+#  - import_role:
+#      name: plugins/roles/appname
+#    when: (appname_enabled | default(False))
+#    tags: appname
+#
+#  - import_tasks: plugins/tasks/appname.yml
+#    when: (appname_enabled | default(False))
+#    tags: appname

--- a/roles/ansible-nas-plugins/defaults/main.yml
+++ b/roles/ansible-nas-plugins/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# enable or disable ansible-nas plugins capability
+plugins_enabled: false

--- a/roles/ansible-nas-plugins/tasks/main.yml
+++ b/roles/ansible-nas-plugins/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- import_tasks: plugins/plugins.yml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

**(completely re-written since the original post)**

This Ansible NAS Plugins addition provides Ansible NAS users the standardized ability to "plugin" additional app containers to their setup without making their Ansible NAS repo clone out of sync with the master branch. Before the plugins feature, changing one line in an Ansible NAS stock script caused downstream user problems of being out of sync with the master repo and thus not being able to stay up to date with the latest fixes and additions provided by the Ansible NAS master branch without undergoing the manual task of fixing the diffs. The Ansible NAS Plugins addition aims to solve this problem by creating a standardized way to add additional app modules that do not effect the core of Ansible NAS.

Once the Ansible NAS Plugins feature has been added into Ansible NAS proper, users can:

* Create and use their own app containers that might not be popular or in demand from the general Ansible NAS user base; e.g. I added PyTivo and LMS to the Ansible NAS base but am probably the only one who used them . Both of these might be contenders to pull out of the Ansible NAS base code and move to plugins that I would be willing to maintain even though I don't use the programs any more.
* Create a (production?) testing environment for Ansible NAS contributors to easily add apps they're working on before moving them over to core with a PR.
* Clone and add app containers from a soon to be big list of Ansible-NAS Plugins repositories created by Ansible NAS enthusiasts such as myself. 
* Frees up @davestephens 's time from moderating "unpopular apps" - he can simply suggest that someone make a plugin instead. :-)

I know this will crate some chatter. Comments and discussion welcome.

This is number one of two major feature additions I am proposing.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

To fully understand the scope and "ecosystem" Ansible NAS Plugins creates, please look at:

World's first Ansible-NAS plugin is available for testing at:
https://github.com/bcurran3/ansible-nas-plugins/tree/main/bcurran3/cleanup

World's first Ansible-NAS Plugins repository:
https://github.com/bcurran3/ansible-nas-plugins
