### PR TITLE
ENHANCMENT: Traefik - add ability to use rules.toml file

### DIFF
--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -5,12 +5,13 @@
     state: directory
   with_items:
     - "{{ traefik_data_directory }}"
+    - "{{ traefik_data_directory }}/data"
     - "{{ traefik_data_directory }}/letsencrypt"
 
 - name: Template Traefik config.toml
   template:
     src: traefik.toml
-    dest: "{{ traefik_data_directory }}/traefik.toml"
+    dest: "{{ traefik_data_directory }}/data/traefik.toml"
   register: template_config
 
 - name: Traefik Docker Container
@@ -20,7 +21,7 @@
     pull: true
     network_mode: host
     volumes:
-      - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
+      - "{{ traefik_data_directory }}/data:/etc/traefik"
       - "{{ traefik_data_directory }}/letsencrypt:/letsencrypt:rw"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     env: "{{ traefik_environment_variables }}"

--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -44,3 +44,7 @@
 
       [certificatesResolvers.letsencrypt.acme.dnsChallenge]
         provider = "{{ traefik_dns_provider }}"
+
+[file]
+filename = "rules.toml"
+watch = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

Adds ability to use a rules.toml file to redirect to websites outside of Ansilbe-NAS

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
