### PR TITLE
FIX: Traefik - traefik_port_http variable defined but never used

### DIFF
--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -1,6 +1,6 @@
 [entryPoints]
   [entryPoints.web]
-    address = ":traefik_port_http"
+    address = ":{{ traefik_port_http }}"
 
   [entryPoints.web.http.redirections.entryPoint]
     to = "websecure"

--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -1,6 +1,6 @@
 [entryPoints]
   [entryPoints.web]
-    address = ":80"
+    address = ":traefik_port_http"
 
   [entryPoints.web.http.redirections.entryPoint]
     to = "websecure"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

In the switch to a role, the variable traefik_port_http was created in the defaults but not used. This implements it's intended purpose.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
