### PR TITLE
Forced traefik to only allow tls1.2+ requests

### DIFF
--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -7,11 +7,17 @@
     - "{{ traefik_data_directory }}"
     - "{{ traefik_data_directory }}/letsencrypt"
 
-- name: Template Traefik config.toml
+- name: Template Traefik traefik.toml
   template:
     src: traefik.toml
     dest: "{{ traefik_data_directory }}/traefik.toml"
   register: template_config
+
+- name: Template Traefik dynamic_config.toml
+  template:
+    src: dynamic_config.toml
+    dest: "{{ traefik_data_directory }}/dynamic_config.toml"
+  register: template_dynamic_config
 
 - name: Traefik Docker Container
   docker_container:
@@ -21,9 +27,10 @@
     network_mode: host
     volumes:
       - "{{ traefik_data_directory }}/traefik.toml:/etc/traefik/traefik.toml:ro"
+      - "{{ traefik_data_directory }}/dynamic_config.toml:/etc/traefik/dynamic_config.toml:ro"
       - "{{ traefik_data_directory }}/letsencrypt:/letsencrypt:rw"
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     env: "{{ traefik_environment_variables }}"
     restart_policy: unless-stopped
     memory: "{{ traefik_memory }}"
-    recreate: "{{ template_config is changed }}"
+    recreate: "{{ template_config is changed or template_dynamic_config is changed }}"

--- a/roles/traefik/templates/dynamic_config.toml
+++ b/roles/traefik/templates/dynamic_config.toml
@@ -1,0 +1,7 @@
+[tls.options]
+
+  [tls.options.default]
+    minVersion = "VersionTLS12"
+
+  [tls.options.mintls13]
+    minVersion = "VersionTLS13"

--- a/roles/traefik/templates/traefik.toml
+++ b/roles/traefik/templates/traefik.toml
@@ -24,6 +24,8 @@
   providersThrottleDuration = "2s"
   [providers.docker]
     exposedbydefault = false
+  [providers.file]
+    filename = "/etc/traefik/dynamic_config.toml"
 
 [api]
   insecure = true


### PR DESCRIPTION
Updated the traefik dynamic config to force clients to use tls1.2 or newer
