### PR TITLE
WIP: ENHANCEMENT - YouTubeDL-Material - add UID/GID env options

### DIFF
--- a/roles/youtubedlmaterial/defaults/main.yml
+++ b/roles/youtubedlmaterial/defaults/main.yml
@@ -9,6 +9,10 @@ youtubedlmaterial_dl_audio_directory: "{{ downloads_root }}/youtube/audio"
 youtubedlmaterial_dl_video_directory: "{{ downloads_root }}/youtube/video"
 youtubedlmaterial_dl_subscriptions_directory: "{{ downloads_root }}/youtube/subscriptions"
 
+# uid / gid
+youtubedlmaterial_user_id: "1000"
+youtubedlmaterial_group_id: "1000"
+
 # network
 youtubedlmaterial_hostname: "youtubedlmaterial"
 youtubedlmaterial_port_http: "8998"

--- a/roles/youtubedlmaterial/tasks/main.yml
+++ b/roles/youtubedlmaterial/tasks/main.yml
@@ -28,6 +28,8 @@
       - "{{ youtubedlmaterial_port_http }}:17442"
     env:
       ALLOW_CONFIG_MUTATIONS: "true"
+      UID: " {{ youtubedlmaterial_user_id }}"
+      GID: " {{ youtubedlmaterial_group_id }}"
       TZ: "{{ ansible_nas_timezone }}"
     restart_policy: unless-stopped
     memory: "{{ youtubedlmaterial_memory }}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:

 YouTubeDL-Material - add UID/GID env options

Not sure if the container supported this when I first added this to AN, but it does now. I left the defaults for UID/GID at the dev's defaults but now they can be overwridden.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

I've had no success setting it to run as root:

> WARNING! Could not change directory ownership. If you manage permissions externally this is fine, otherwise you may experience issues when downloading or deleting videos.
> error: failed switching to " 0: 0": unable to find user  0: no matching entries in passwd file
> find: ' 0' is not the name of a known user

It says "this is fine" but the container reboots. I have not tried setting to other UID's or GUD's, but now the option is there to play with. :->