### PR TITLE
Fixed linting errors

### DIFF
--- a/roles/emby/tasks/main.yml
+++ b/roles/emby/tasks/main.yml
@@ -6,7 +6,7 @@
   with_items:
     - "{{ emby_config_directory }}"
 
-- name: emby Docker Container
+- name: Emby Docker Container
   docker_container:
     name: emby
     image: emby/embyserver

--- a/roles/get_iplayer/tasks/main.yml
+++ b/roles/get_iplayer/tasks/main.yml
@@ -7,7 +7,7 @@
     - "{{ get_iplayer_config_directory }}"
     - "{{ get_iplayer_download_directory }}"
 
-- name: get_iplayer Docker Container
+- name: Get_iplayer Docker Container
   docker_container:
     name: get_iplayer
     image: kolonuk/get_iplayer

--- a/roles/jackett/tasks/main.yml
+++ b/roles/jackett/tasks/main.yml
@@ -6,7 +6,7 @@
   with_items:
     - "{{ jackett_data_directory }}"
 
-- name: jackett
+- name: Jackett
   docker_container:
     name: jackett
     image: linuxserver/jackett

--- a/roles/komga/tasks/main.yml
+++ b/roles/komga/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ komga_data_directory }}"
     - "{{ komga_data_directory }}/config"
 
-- name: komga Docker Container
+- name: Komga Docker Container
   docker_container:
     name: komga
     image: gotson/komga

--- a/roles/mylar/tasks/main.yml
+++ b/roles/mylar/tasks/main.yml
@@ -7,7 +7,7 @@
   with_items:
     - "{{ mylar_data_directory }}/config"
 
-- name: mylar Docker Container
+- name: Mylar Docker Container
   docker_container:
     name: mylar
     image: linuxserver/mylar

--- a/roles/mymediaforalexa/tasks/main.yml
+++ b/roles/mymediaforalexa/tasks/main.yml
@@ -7,7 +7,7 @@
     - "{{ mymediaforalexa_media_directory }}"
     - "{{ mymediaforalexa_data_directory }}"
 
-- name: mymediaforalexa Docker Container
+- name: Mymediaforalexa Docker Container
   docker_container:
     name: mymediaforalexa
     image: bizmodeller/mymediaforalexa

--- a/roles/n8n/tasks/main.yml
+++ b/roles/n8n/tasks/main.yml
@@ -6,7 +6,7 @@
   with_items:
     - "{{ n8n_data_directory }}"
 
-- name: n8n Docker Container
+- name: N8n Docker Container
   docker_container:
     name: n8n
     image: n8nio/n8n

--- a/roles/netbootxyz/tasks/main.yml
+++ b/roles/netbootxyz/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: netbootxyz Directory
+- name: Netbootxyz Directory
   file:
     path: "{{ item }}"
     state: directory
@@ -7,7 +7,7 @@
     - "{{ netbootxyz_config_directory }}"
     - "{{ netbootxyz_assets_directory }}"
 
-- name: netbootxyz Docker Container
+- name: Netbootxyz Docker Container
   docker_container:
     name: netbootxyz
     image: linuxserver/netbootxyz:latest

--- a/roles/paperless_ng/tasks/main.yml
+++ b/roles/paperless_ng/tasks/main.yml
@@ -12,12 +12,11 @@
     - "{{ paperless_ng_media_directory }}"
     - "{{ paperless_ng_consume_directory }}"
 
-
 - name: Create paperless_ng network
   docker_network:
     name: "{{ paperless_ng_container_network_name }}"
 
-- name: paperless_ng redis broker
+- name: Paperless_ng redis broker
   docker_container:
     name: "{{ paperless_ng_container_name_redis }}"
     image: redis:6.0
@@ -27,7 +26,7 @@
     networks:
       - name: "{{ paperless_ng_container_network_name }}"
 
-- name: paperless_ng postgres Docker Container
+- name: Paperless_ng postgres Docker Container
   docker_container:
     name: "{{ paperless_ng_container_name_postgres }}"
     image: postgres:13
@@ -43,7 +42,7 @@
     networks:
       - name: "{{ paperless_ng_container_network_name }}"
 
-- name: paperless_ng UI Docker Container
+- name: Paperless_ng UI Docker Container
   docker_container:
     name: "{{ paperless_ng_container_name_uiserver }}"
     image: jonaswinkler/paperless-ng:latest

--- a/roles/piwigo/tasks/main.yml
+++ b/roles/piwigo/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ piwigo_data_directory }}"
     - "{{ piwigo_photos }}"
 
-- name: create MySQL container for Piwigo
+- name: Create MySQL container for Piwigo
   docker_container:
     name: piwigo-mysql
     image: mysql:5.7

--- a/roles/plex/tasks/main.yml
+++ b/roles/plex/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ plex_config_directory }}"
     - "{{ plex_logs }}"
 
-- name: plex Docker Container
+- name: Plex Docker Container
   docker_container:
     name: plex
     image: linuxserver/plex

--- a/roles/prowlarr/tasks/main.yml
+++ b/roles/prowlarr/tasks/main.yml
@@ -6,7 +6,7 @@
   with_items:
     - "{{ prowlarr_data_directory }}"
 
-- name: prowlarr
+- name: Prowlarr
   docker_container:
     name: prowlarr
     image: ghcr.io/linuxserver/prowlarr:develop

--- a/roles/pyload/tasks/main.yml
+++ b/roles/pyload/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ pyload_config_directory }}"
     - "{{ pyload_download_directory }}"
 
-- name: pyLoad Docker Container
+- name: PyLoad Docker Container
   docker_container:
     name: pyload
     image: writl/pyload

--- a/roles/utorrent/tasks/main.yml
+++ b/roles/utorrent/tasks/main.yml
@@ -8,7 +8,7 @@
     - "{{ utorrent_download_directory }}"
     - "{{ utorrent_download_directory_active }}"
 
-- name: uTorrent Docker Container
+- name: UTorrent Docker Container
   docker_container:
     name: utorrent
     image: ekho/utorrent:latest

--- a/roles/youtubedlmaterial/tasks/main.yml
+++ b/roles/youtubedlmaterial/tasks/main.yml
@@ -13,7 +13,7 @@
     - "{{ youtubedlmaterial_dl_video_directory }}"
     - "{{ youtubedlmaterial_dl_subscriptions_directory }}"
 
-- name: youtubedlmaterial Docker Container
+- name: Youtubedlmaterial Docker Container
   docker_container:
     name: youtubedlmaterial
     image: tzahi12345/youtubedl-material:latest


### PR DESCRIPTION
Where do these new linting errors come from? The failing commit doesn't seem to have introduced new upgrades for the `ansible-lint` package, which is the one complaining. We can also avoid this issue by adding `name` to the `skip_list` of `.ansible-lint` I believe
