### PR TITLE
FIX: Ubooquity variable name

### DIFF
--- a/roles/ubooquity/tasks/main.yml
+++ b/roles/ubooquity/tasks/main.yml
@@ -28,7 +28,7 @@
     memory: "{{ ubooquity_memory }}"
     labels:
       traefik.enable: "{{ ubooquity_available_externally | string }}"
-      traefik.http.routers.ubooquity.rule: "Host(`{{ ubooquity }}.{{ ansible_nas_domain }}`)"
+      traefik.http.routers.ubooquity.rule: "Host(`{{ ubooquity_hostname }}.{{ ansible_nas_domain }}`)"
       traefik.http.routers.ubooquity.tls.certresolver: "letsencrypt"
       traefik.http.routers.ubooquity.tls.domains[0].main: "{{ ansible_nas_domain }}"
       traefik.http.routers.ubooquity.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The Ubooquity role contained a variable 'ubooquity' which is supposed
to be 'ubooquity_hostname'. Fix it.

**Which issue (if any) this PR fixes**:

I did not create an issue; just the PR.