### PR TITLE
FIX: transmission_with_openvpn  - add variable to match name used in task

### DIFF
--- a/roles/transmission-with-openvpn/defaults/main.yml
+++ b/roles/transmission-with-openvpn/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 transmission_with_openvpn_enabled: false # Please see docs about how to set VPN credentials
 transmission_with_openvpn_available_externally: false
+transmission_openvpn_available_externally: false
 
 # directories
 transmission_config_directory: "{{ docker_home }}/transmission/config"


### PR DESCRIPTION
**What this PR does / why we need it**:

The transmission_with_openvpn task with fails `The task includes an option with an undefined variable.`

**Which issue (if any) this PR fixes**:

Closes #603

**Any other useful info**:

In the transmission_with_openvpn task, the variable used is:
    `transmission_openvpn_available_externally`
In the transmission_with_openvpn defaults, the variable is:
    `transmission_with_openvpn_available_externally`
To reconcile this, I added the former variable into the default.
I left the extra `*_available_externally` variable in defaults in case it's
used elsewhere, but a quick search in the repo showed it's not used.
The extra one could be deleted, but I'll leave that up to the merger.