### PR TITLE
FIX: Deluge conditional fails parsing

### DIFF
--- a/roles/deluge/tasks/main.yml
+++ b/roles/deluge/tasks/main.yml
@@ -32,7 +32,7 @@
           traefik.http.routers.deluge.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.deluge.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.deluge.loadbalancer.server.port: "8112"
-  when: when deluge_enabled is true
+  when: deluge_enabled is true
 
 - name: Stop Deluge
   block:


### PR DESCRIPTION
**What this PR does / why we need it**:

The `when:` clause had an additional`when` which needs removal to avoid failure.

**Which issue (if any) this PR fixes**:

No issue created.

**Any other useful info**:
