### PR TITLE
FIX: Firefly3 - Add environment variables to fix broken login page form

### DIFF
--- a/roles/firefly/tasks/main.yml
+++ b/roles/firefly/tasks/main.yml
@@ -42,6 +42,8 @@
         ports:
           - "{{ firefly_port }}:8080"
         env:
+          APP_URL: "https://{{ firefly_hostname }}.{{ ansible_nas_domain }}"
+          TRUSTED_PROXIES: "**"
           APP_ENV: "local"
           APP_KEY: "S0m3R@nd0mString0f32Ch@rsEx@ct1y"
           DB_CONNECTION: "mysql"


### PR DESCRIPTION
**What this PR does / why we need it**:

When running Firefly3 behind a reverse proxy, the login page form tries to use a plan HTTP connection which causes the login to fail with the following error:

```sh
refused to send form data to 'http://domain/register' because it violates the following Content Security Policy directive: "form-action 'self'".
```

In the logs:

```
[2022-10-26T22:38:52.075027+13:00] local.INFO: AUDIT: Show login form (1.1). (172.17.0.1 -> GET:**http**://firefly.mydomain.tld/login) [] []
```

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:

By setting the following variables in the env the app logs in successfully:

```
APP_URL=https://firefly.mydomain.tld
TRUSTED_PROXIES=**
```

```
[2022-10-26T22:56:39.877379+13:00] local.INFO: AUDIT: Show login form (1.1). (192.168.60.184 -> GET:**https**://firefly.mydomain.tld/login) [] []
```