### PR TITLE
Use proper app name in speedtest help page

### DIFF
--- a/website/docs/applications/monitoring/speedtest.md
+++ b/website/docs/applications/monitoring/speedtest.md
@@ -10,8 +10,8 @@ Continuously track your internet speed
 
 ## Usage
 
-Set `speedtest_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+Set `speedtest_tracker_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
 
-If you want to access Speedtest-Tracker externally, don't forget to set `speedtest_available_externally: true` in your `inventories/<your_inventory>/nas.yml` file.
+If you want to access Speedtest-Tracker externally, don't forget to set `speedtest_tracker_available_externally: true` in your `inventories/<your_inventory>/nas.yml` file.
 
 The Speedtest-Tracker interface can be found at <http://ansible_nas_host_or_ip:8765>.


### PR DESCRIPTION
**What this PR does / why we need it**: fixes misleading bug in speedtest help page