### PR TITLE
Add pre_task veryfing minimal ansible version

### DIFF
--- a/nas.yml
+++ b/nas.yml
@@ -1,6 +1,12 @@
 ---
 - hosts: all
 
+  pre_tasks:
+    - name: Verify Ansible meets ansible-nas version requirements.
+      assert:
+        that: "ansible_version.full is version_compare('2.10', '>=')"
+        msg: "update Ansible to at least 2.10 to install ansible-nas"
+
   roles:
     ###
     ### Requirements


### PR DESCRIPTION
On gitter chat there is number of people having issue with first installation of ansible-nas (including me). In many cases it is incorrect version of ansible. Currently error message is not very helpful as it is showing rather syntax error and not version mismatch. This change is based on: [this page](https://www.jeffgeerling.com/blog/2018/require-minimum-ansible-version-your-playbook)

**What this PR does / why we need it**: adds pre-check for minimal version of Ansible
