### PR TITLE
Fix nomad when nomad_enabled is false

### DIFF
--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -38,3 +38,4 @@
         state: stopped
         enabled: no
   when: nomad_enabled is false
+  ignore_errors: true


### PR DESCRIPTION
Ignore errors if unit doesn't exist