### PR TITLE
Fix drone ci tests

### DIFF
--- a/roles/drone-ci/handlers/main.yml
+++ b/roles/drone-ci/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart gitea
+- name: Restart gitea
   community.docker.docker_container:
     name: gitea
     image: gitea/gitea:latest

--- a/roles/drone-ci/handlers/main.yml
+++ b/roles/drone-ci/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+- name: restart gitea
+  community.docker.docker_container:
+    name: gitea
+    image: gitea/gitea:latest
+    state: started
+    restart: true
+  listen: "restart gitea"

--- a/roles/drone-ci/molecule/default/molecule.yml
+++ b/roles/drone-ci/molecule/default/molecule.yml
@@ -8,3 +8,6 @@ provisioner:
         drone_ci_gitea_client_secret: asdfasd12341234
         gitea_port_http: 3001
         ansible_nas_hostname: ansible-nas-ci
+        gitea_data_directory: "/tmp"
+  playbooks:
+    prepare: prepare.yml

--- a/roles/drone-ci/molecule/default/prepare.yml
+++ b/roles/drone-ci/molecule/default/prepare.yml
@@ -1,0 +1,25 @@
+---
+- name: Prepare
+  hosts: all
+  tasks:
+    - name: Install docker python module
+      pip:
+        name: docker
+
+    - name: Create a dummy gitea config directory
+      file:
+        path: "{{ item }}"
+        state: directory
+        recurse: yes
+      with_items:
+        - "{{ gitea_data_directory }}/gitea/gitea/conf"
+
+    - name: Create a dummy gitea config file
+      file:
+        path: "{{ gitea_data_directory }}/gitea/gitea/conf/app.ini"
+        state: touch
+
+  handlers:
+    - name: restart gitea
+      command: echo "this task will restart gitea"
+      listen: "restart gitea"

--- a/roles/drone-ci/molecule/default/prepare.yml
+++ b/roles/drone-ci/molecule/default/prepare.yml
@@ -18,8 +18,3 @@
       file:
         path: "{{ gitea_data_directory }}/gitea/gitea/conf/app.ini"
         state: touch
-
-  handlers:
-    - name: restart gitea
-      command: echo "this task will restart gitea"
-      listen: "restart gitea"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:
Fixes Molecule Test for Drone-CI:
`
TASK [drone-ci : Add webhook allowed hosts to Gitea] ***************************
  fatal: [instance]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'gitea_data_directory' is undefined. 'gitea_data_directory' is undefined\n\nThe error appears to be in '/github/workspace/roles/drone-ci/tasks/main.yml': line 67, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Add webhook allowed hosts to Gitea\n      ^ here\n"}
`


**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
