### PR TITLE
Fix #621

### DIFF
--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Get the list of services
+  service_facts:
+
 - name: Install and start Nomad
   block:
     - name: Add Hashicorp GPG key
@@ -30,11 +33,27 @@
         enabled: yes
   when: nomad_enabled is true
 
-- name: Stop Nomad
+- name: Stop and uninstall Nomad
   block:
     - name: Stop Nomad
       ansible.builtin.systemd:
         name: "{{ nomad_service_name }}"
         state: stopped
         enabled: no
-  when: nomad_enabled is false
+        daemon_reload: yes
+
+    - name: Uninstall Nomad
+      ansible.builtin.apt:
+        name: nomad
+        state: absent
+        purge: true
+
+    - name: Remove Nomad config
+      ansible.builtin.file:
+        path: /etc/nomad.d/nomad.hcl
+        state: absent
+
+    - name: Reload systemd
+      ansible.builtin.systemd:
+        daemon_reload: yes
+  when: nomad_enabled is false and nomad_service_name + '.service' in services


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:
Issue #621 still seems to be valid. Looks like Nomad is using the new approach of enabling applications, meaning it is not behind `when: (nomad_enabled | default(False))`, thus the role is always run, thus the Stop Nomad task is always run. And unlike all the other cases where we are stopping a docker container, here we are stopping a systemd service. We have `nomad_enabled: false` by default, but the service is not there and hence the error. So like @fetherolfjd suggests in the issue, we can check if the service is present in the conditional.

This is my proposed fix, maybe a little expanded to actually remove the service, not just stop (Since enabling the flag to `true` is actually installing and enabling the service, so disabling the flag should clean up everything?)

I tested it only using `-t nomad`, and at least there the error is gone.

**Which issue (if any) this PR fixes**:

Fixes #621

**Any other useful info**:
