### PR TITLE
:sparkles: Add badge with role count

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Ansible NAS
 
+![Available Applications](https://img.shields.io/github/directory-file-count/davestephens/ansible-nas/roles?label=Available%20Applications&style=flat-square)
 [![CI](https://github.com/davestephens/ansible-nas/workflows/CI/badge.svg)](https://github.com/davestephens/ansible-nas/actions?query=workflow%3ACI)
 [![Integration](https://github.com/davestephens/ansible-nas/workflows/Integration/badge.svg)](https://github.com/davestephens/ansible-nas/actions?query=workflow%3AIntegration)
 [![Gitter chat](https://img.shields.io/gitter/room/ansible-nas/chat.svg?logo=gitter&style=flat-square)](https://gitter.im/Ansible-NAS/Chat)
@@ -14,7 +15,7 @@ You can configure Ansible-NAS to set up any (or all!) of the applications listed
 
 If you have a spare domain name you can configure applications to be accessible externally to your home LAN too; they'll be configured with a sensible hostname and DNS gets updated accordingly if your home IP address changes.
 
-## Available Applications ![Roles](https://img.shields.io/github/directory-file-count/davestephens/ansible-nas/roles?label=Roles)
+## Available Applications
 
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You can configure Ansible-NAS to set up any (or all!) of the applications listed
 
 If you have a spare domain name you can configure applications to be accessible externally to your home LAN too; they'll be configured with a sensible hostname and DNS gets updated accordingly if your home IP address changes.
 
-## Available Applications
+## Available Applications ![Roles](https://img.shields.io/github/directory-file-count/davestephens/ansible-nas/roles?label=Roles)
 
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a badge that shows the number of roles/applications. It counts the number of directories in `roles` directory. The count is approximate (we have 3 internal roles), but still it's nice ;)

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
