### PR TITLE
changes the port used inside gitea container to 22

### DIFF
--- a/roles/gitea/tasks/main.yml
+++ b/roles/gitea/tasks/main.yml
@@ -53,7 +53,7 @@
           DB_PASSWD: "gitea"
           RUN_MODE: "prod"
           SSH_DOMAIN: "{{ ansible_nas_hostname }}"
-          SSH_PORT: "{{ gitea_port_ssh }}"
+          SSH_PORT: "22"
           ROOT_URL: "http://{{ gitea_hostname }}:{{ gitea_port_http }}/"
           USER_UID: "1000"
           USER_GID: "1000"


### PR DESCRIPTION
Hi! First off: thanks for creating this project! I've found it invaluable and have cribbed extensive sections of it for my personal use.

I'm committing a fairly large faux-pas as I don't run this project directly, and was too lazy to run the vagrant tests (I tried but would need to reconfigure some network settings for Virtualbox to run them correctly and have run out of time). However, I'm pretty confident the code change fixes an issue.

This updates the gitea container so it uses port 22 for SSH instead of `{{ gitea_port_ssh }}`. This seems to be correct as this port is forwarded using `"{{ gitea_port_ssh }}:22"` a few lines above, so it follows that the environment variable `SSH_PORT` should be hard-set to 22 as well.

At least, this was my finding when I copied the bulk of the gitea config and ran it locally: the website worked right away, but cloning projects using ssh failed because gitea was originally running ssh using port 222 inside the container while forwarding port 22 to 222 on the host.

Again, my apologies if I've missed something and this PR ends up wasting someone's time.