### PR TITLE
netdata: make it configurable and run as non root

### DIFF
--- a/roles/netdata/defaults/main.yml
+++ b/roles/netdata/defaults/main.yml
@@ -2,6 +2,22 @@
 netdata_enabled: false
 netdata_available_externally: false
 
+# directories
+netdata_data_directory: "{{ docker_home }}/netdata"
+
+netdata_directories:
+  - "{{ netdata_data_directory }}"
+  - "{{ netdata_data_directory }}/etc"
+  - "{{ netdata_data_directory }}/dbengine"
+netdata_directories_custom: []
+
+# templates
+netdata_template_files:
+  - src: netdata.conf.j2
+    dest: "{{ netdata_data_directory }}/etc/netdata.conf"
+    force: "true"
+netdata_template_files_custom: []
+
 # network
 netdata_hostname: "netdata"
 netdata_port: "19999"
@@ -13,3 +29,16 @@ netdata_image_version: "latest"
 
 # specs
 netdata_memory: 1g
+netdata_volumes:
+  - "/proc:/host/proc:ro"
+  - "/sys:/host/sys:ro"
+  - "/var/run/docker.sock:/var/run/docker.sock:ro"
+  - "{{ netdata_data_directory }}/etc/netdata.conf:/etc/netdata/netdata.conf:ro"
+  - "{{ netdata_data_directory }}/dbengine:/var/cache/netdata/dbengine:rw"
+netdata_volumes_custom: []
+
+# config - https://learn.netdata.cloud/docs/configure/common-changes
+netdata_config:
+  global:
+    - "page cache size = 32"                # MiB of RAM used to store metrics
+    - "dbengine multihost disk space = 128" # MiB of disk to store history

--- a/roles/netdata/tasks/main.yml
+++ b/roles/netdata/tasks/main.yml
@@ -6,6 +6,51 @@
         name: docker
       register: docker_group
 
+    - name: Create netdata group
+      become: true
+      ansible.builtin.group:
+        name: netdata
+        gid: "201"
+        state: present
+      register: netdata_group
+
+    - name: Create netdata user
+      become: true
+      ansible.builtin.user:
+        name: netdata
+        state: present
+        system: yes
+        create_home: no
+        group: netdata
+        groups:
+          - "{{ docker_group.gid }}"
+        uid: "201"
+        shell: /usr/sbin/nologin
+      register: netdata_user
+
+    - name: Create Directories
+      become: true
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0750"
+        owner: "netdata"
+        group: "netdata"
+      with_items: "{{ netdata_directories + netdata_directories_custom | unique | sort }}"
+      when: netdata_user.state == "present" and netdata_group.state == "present"
+      ignore_errors: "{{ ansible_check_mode }}"
+
+    - name: Template Files
+      become: true
+      register: template_config
+      ansible.builtin.template:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        force: "{{ item.force | default(false) }}"
+        mode: "{{ item.mode | default('0600') }}"
+      with_items: "{{ netdata_template_files + netdata_template_files_custom | unique | sort }}"
+      ignore_errors: "{{ ansible_check_mode }}"
+
     - name: Netdata Docker Container
       community.docker.docker_container:
         name: "{{ netdata_container_name }}"
@@ -15,10 +60,7 @@
         pull: true
         ports:
           - "{{ netdata_port }}:19999"
-        volumes:
-          - "/proc:/host/proc:ro"
-          - "/sys:/host/sys:ro"
-          - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        volumes: "{{ netdata_volumes + netdata_volumes_custom | unique | sort }}"
         env:
           PGID: "{{ docker_group.gid }}"
         capabilities:
@@ -27,6 +69,7 @@
           - apparmor:unconfined
         restart_policy: unless-stopped
         memory: "{{ netdata_memory }}"
+        recreate: "{{ template_config is changed }}"
         labels:
           traefik.enable: "{{ netdata_available_externally | string }}"
           traefik.http.routers.netdata.rule: "Host(`{{ netdata_hostname }}.{{ ansible_nas_domain }}`)"

--- a/roles/netdata/templates/netdata.conf.j2
+++ b/roles/netdata/templates/netdata.conf.j2
@@ -1,0 +1,4 @@
+{% for key,value in netdata_config.items() %}
+[{{ key }}]
+  {{ value | join("\n") | indent(2) }}
+{% endfor %}


### PR DESCRIPTION
**What this PR does / why we need it**:
- makes netdata configurable
- adds ability to store data for longer
- runs the container as non root user