### PR TITLE
Replace deprecated VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
     "recommendations": [
         "redhat.ansible",
         "redhat.vscode-yaml",
-        "ybaumes.highlight-trailing-white-spaces",
-        "bungcip.better-toml"
+        "tamasfe.even-better-toml",
+        "ybaumes.highlight-trailing-white-spaces"
     ]
 }


### PR DESCRIPTION
There was a warning appearing in VSCode regarding a deprecated extension.

I have resolved the issue by replacing the deprecated extension with the alternative suggested by VSCode.
