### PR TITLE
Update Transmission Role External Port

### DIFF
--- a/roles/transmission/defaults/main.yml
+++ b/roles/transmission/defaults/main.yml
@@ -13,7 +13,7 @@ transmission_group_id: "0"
 
 # network
 transmission_webui_port: "9092"
-transmission_external_port: "51414"
+transmission_external_port: "51413"
 transmission_hostname: "transmission"
 
 transmission_timezone: "{{ ansible_nas_timezone }}"


### PR DESCRIPTION
Update Role Transmission external port to 51413 to match external port defined in Task so that Listening Port can be "open"

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
2. Ensure you have tested new functionality using tests/test-vagrant.sh.
3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.

-->

**What this PR does / why we need it**:
 Update Transmission Role External Port: updates Role Transmission external port to 51413 to match external port defined in Task so that Listening Port can be "open"


**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
Was unable to detect open listening port within Transmission without matching ports and forwarding in router.