### PR TITLE
portainer: option to set whielisted ips in traefik, use port from vars

### DIFF
--- a/roles/portainer/defaults/main.yml
+++ b/roles/portainer/defaults/main.yml
@@ -8,6 +8,7 @@ portainer_data_directory: "{{ docker_home }}/portainer/config"
 # network
 portainer_port: "9000"
 portainer_hostname: "portainer"
+portainer_ip_whitelist: "0.0.0.0/0"
 
 # docker
 portainer_container_name: "portainer"

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -28,6 +28,8 @@
           traefik.http.routers.portainer.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.portainer.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
           traefik.http.services.portainer.loadbalancer.server.port: "9443"
+          traefik.http.routers.portainer.middlewares: "portainer-ipwhitelist@docker"
+          traefik.http.middlewares.portainer-ipwhitelist.ipwhitelist.sourcerange: "{{ portainer_ip_whitelist }}"
   when: portainer_enabled is true
 
 - name: Stop Portainer


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds same ability to whitelist IPs in traefik for portainer as we have it in bitwarden.
- Sets portainer port to use the one defined in the variables.

**Any other useful info**:
Example for bitwarden: https://github.com/davestephens/ansible-nas/blob/62111605753dfa6f140df21a04c905569b404817/roles/bitwarden/tasks/main.yml#L34