### PR TITLE
Make tests working and passing again

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 
-1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/master/CONTRIBUTING.md.
+1. If this is your first PR against Ansible-NAS, please read our contributor guidelines - https://github.com/davestephens/ansible-nas/blob/main/CONTRIBUTING.md.
 2. Ensure you have tested new functionality using tests/test-vagrant.sh.
 3. If the PR is unfinished, add `WIP:` at the beginning of the title or use the Github Draft PR feature.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 
 # Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
 
@@ -35,6 +35,6 @@ jobs:
         run: yamllint .
 
       - name: Lint docs
-        uses: articulate/actions-markdownlint@v1
+        uses: articulate/actions-markdownlint@v1.1.0
         with:
           version: 0.32.2

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint docs
-        uses: articulate/actions-markdownlint@v1
+        uses: articulate/actions-markdownlint@v1.1.0
         with:
           version: 0.32.2
 
@@ -24,9 +24,9 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -4,7 +4,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -4,7 +4,7 @@ name: Test Website Deployment
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Lint docs
-        uses: articulate/actions-markdownlint@v1
+        uses: articulate/actions-markdownlint@v1.1.0
         with:
           version: 0.32.2
 
@@ -24,8 +24,8 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Generate Test Matrix
         id: set-matrix
         shell: bash
@@ -29,7 +29,7 @@ jobs:
         matrix:
             role: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Molecule Test
         uses: gofrolist/molecule-action@dfbfd1af6a77523c8a937a1532f92808065a00a4
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/davestephens/ansible-nas/workflows/CI/badge.svg)](https://github.com/davestephens/ansible-nas/actions?query=workflow%3ACI)
 [![Integration](https://github.com/davestephens/ansible-nas/workflows/Integration/badge.svg)](https://github.com/davestephens/ansible-nas/actions?query=workflow%3AIntegration)
 [![Gitter chat](https://img.shields.io/gitter/room/ansible-nas/chat.svg?logo=gitter&style=flat-square)](https://gitter.im/Ansible-NAS/Chat)
-[![license](https://img.shields.io/github/license/DAVFoundation/api_doc.svg?style=flat-square)](https://github.com/davestephens/ansible-nas/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/DAVFoundation/api_doc.svg?style=flat-square)](https://github.com/davestephens/ansible-nas/blob/main/LICENSE)
 [![Ko-fi](https://img.shields.io/static/v1.svg?label=ko-fi&message=Buy%20Me%20A%20Coffee&color=orange&style=flat-square&logo=buy-me-a-coffee)](https://ko-fi.com/davestephens)
 
 After getting burned by broken FreeNAS updates one too many times, I figured I could do a much better job myself using just a stock Ubuntu install, some clever Ansible config and a bunch of Docker containers.

--- a/roles/ansible-nas-general/tasks/main.yml
+++ b/roles/ansible-nas-general/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Install LazyDocker
   ansible.builtin.shell:
-    cmd: curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
+    cmd: set -o pipefail && curl https://raw.githubusercontent.com/jesseduffield/lazydocker/master/scripts/install_update_linux.sh | bash
   args:
     creates: /usr/local/bin/lazydocker
   environment:

--- a/roles/n8n/defaults/main.yml
+++ b/roles/n8n/defaults/main.yml
@@ -15,7 +15,7 @@ n8n_basic_auth_password: "n8n_change_me"
 
 # docker
 n8n_container_name: "n8n"
-n8n_image_name: "n8nio/n8n"
+n8n_image_name: "docker.n8n.io/n8nio/n8n"
 n8n_image_version: "latest"
 
 # specs

--- a/roles/n8n/molecule/default/molecule.yml
+++ b/roles/n8n/molecule/default/molecule.yml
@@ -1,6 +1,17 @@
 ---
+platforms:
+  - name: instance
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /tmp:/tmp:rw
+    privileged: true
+    pre_build_image: true
+
 provisioner:
   inventory:
     group_vars:
       all:
         n8n_enabled: true
+        n8n_data_directory: "/tmp/n8n"

--- a/roles/n8n/tasks/main.yml
+++ b/roles/n8n/tasks/main.yml
@@ -5,6 +5,8 @@
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
+        owner: 1000
+        group: 1000
       with_items:
         - "{{ n8n_data_directory }}"
 

--- a/tests/github-test-matrix.sh
+++ b/tests/github-test-matrix.sh
@@ -8,4 +8,4 @@ for f in ./roles/*; do
   fi
 done
 
-echo "::set-output name=matrix::$(echo $test_matrix | jq -R -s -c 'sub("\n"; " ") | split(" ")[:-1]')"
+echo "matrix=$(echo $test_matrix | jq -R -s -c 'sub("\n"; " ") | split(" ")[:-1]')" >> $GITHUB_OUTPUT

--- a/website/docs/applications/system-tools/ddns_updater.md
+++ b/website/docs/applications/system-tools/ddns_updater.md
@@ -16,7 +16,6 @@ Set `ddns_updater_enabled: true` in your `inventories/<your_inventory>/group_var
 
 Ensure that the `ddns_updater_config` variable is set with your DDNS Updater configuration. The configuration is converted from YAML into JSON, required by the DDNS Updater application. Use [json2yaml](https://www.json2yaml.com/) to check your configuration format.
 
-
 The following configuration:
 
 ```yaml

--- a/website/docs/upgrading.md
+++ b/website/docs/upgrading.md
@@ -5,7 +5,7 @@ Upgrading consists of two steps - firstly updating the Ansible-NAS code on your 
 Assuming you haven't changed anything except the files in your inventory directory, you can simply run:
 
 ```bash
-git pull origin master
+git pull origin main
 ```
 
 ...to pull the latest updates from GitHub. If you've changed files outside of the inventory directory, you'll need to fix any merge conflicts.

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -38,7 +38,7 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/davestephens/ansible-nas/tree/master/website',
+            'https://github.com/davestephens/ansible-nas/tree/main/website',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does a couple things:
1. Updates all references to former `master` branch to current `main` branch - so that links and actions work again.
2. Updates actions (checkout, setup-python, setup-node) to latest versions to get rid of warnings.
3. Updates `articulate/actions-markdownlint` action to v1.1.0 which supports the `version` input <- this is still showing as a warning though, so not sure what's going on :(


4. Fix linting and n8n role so that tests are passing.

Some references:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
https://github.blog/changelog/2023-07-17-github-actions-removal-of-node12-from-the-actions-runner/
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/



**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
