### PR TITLE
Host your own Rust Desk relay server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you have a spare domain name you can configure applications to be accessible 
 * [Radarr](https://radarr.video/) - for organising and downloading movies
 * [Route53 DDNS](https://crazymax.dev/ddns-route53/) - Automatically update AWS Route53 with your IP address
 * [RSS-Bridge](https://rss-bridge.github.io/rss-bridge/) - The RSS feed for websites missing it
+* [RustDesk](https://rustdesk.com) - RustDesk is a full-featured remote desktop app. Works on Windows, macOS, Linux, iOS, Android, Web. Own your data, easily set up self-hosting solution on your infrastructure.
 * [Sabnzbd](https://sabnzbd.org/) - A powerful usenet downloader that FreeNAS provides
 * [Sickchill](https://sickchill.github.io/) - for managing TV episodes
 * [Sonarr](https://sonarr.tv/) - for downloading and managing TV episodes

--- a/nas.yml
+++ b/nas.yml
@@ -338,6 +338,10 @@
       tags:
         - rssbridge
 
+    - role: rustdesk
+      tags:
+        - rustdesk
+
     - role: sabnzbd
       tags:
         - sabnzbd

--- a/roles/rustdesk/defaults/main.yml
+++ b/roles/rustdesk/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+rustdesk_enabled: false
+rustdesk_available_externally: false
+
+# directories
+rustdesk_data_directory: "{{ docker_home }}/rustdesk"
+
+# network
+rustdesk_hostname: "rustdesk"
+rustdesk_network_name: rustdesknet
+ansible_nas_domain: "example.com"
+
+# specs
+rustdesk_memory: 512g
+
+# docker
+rustdesk_container_name: rustdesk
+rustdesk_image_name: rustdesk/rustdesk-server
+rustdesk_image_version: latest

--- a/roles/rustdesk/handlers/main.yml
+++ b/roles/rustdesk/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart rustdesk
+  community.docker.docker_container:
+    name: "{{ rustdesk_container_name }}"
+    restart: true
+  listen: "restart rustdesk"

--- a/roles/rustdesk/molecule/default/molecule.yml
+++ b/roles/rustdesk/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        rustdesk_enabled: true

--- a/roles/rustdesk/molecule/default/side_effect.yml
+++ b/roles/rustdesk/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        rustdesk_enabled: false

--- a/roles/rustdesk/molecule/default/verify.yml
+++ b/roles/rustdesk/molecule/default/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get rustdesk container state
+      community.docker.docker_container:
+        name: "{{ rustdesk_container_name }}"
+      register: result
+
+    - name: Check if rustdesk containers are running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/rustdesk/molecule/default/verify_stopped.yml
+++ b/roles/rustdesk/molecule/default/verify_stopped.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove rustdesk
+      community.docker.docker_container:
+        name: "{{ rustdesk_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check if rustdesk is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/rustdesk/tasks/main.yml
+++ b/roles/rustdesk/tasks/main.yml
@@ -1,0 +1,64 @@
+---
+- name: Start rustdesk
+  block:
+    - name: Create rustdesk Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        recurse: yes
+      with_items:
+        - "{{ rustdesk_data_directory }}/rustdesk"
+
+    - name: Create rustdesk network
+      community.docker.docker_network:
+        name: "{{ rustdesk_network_name }}"
+
+    - name: Create container for rustdesk-hbbr
+      community.docker.docker_container:
+        name: "{{ rustdesk_container_name }}-hbbr"
+        image: "{{ rustdesk_image_name }}:{{ rustdesk_image_version }}"
+        pull: true
+        networks:
+          - name: "{{ rustdesk_network_name }}"
+        network_mode: "{{ rustdesk_network_name }}"
+        ports:
+          - "21117:21117"
+          - "21119:21119"
+        volumes:
+          - "{{ rustdesk_data_directory }}:/root:rw"
+        command: hbbr
+        restart_policy: unless-stopped
+        memory: "{{ rustdesk_memory }}"
+
+    - name: Create rustdesk container
+      community.docker.docker_container:
+        name: "{{ rustdesk_container_name }}"
+        image: "{{ rustdesk_image_name }}:{{ rustdesk_image_version }}"
+        pull: true
+        command: "hbbs -r {{rustdesk_container_name}}.{{ansible_nas_domain}}:21117"
+        networks:
+          - name: "{{ rustdesk_network_name }}"
+        network_mode: "{{ rustdesk_network_name }}"
+        volumes:
+          - "{{ rustdesk_data_directory }}:/root:rw"
+        ports:
+          - "21115:21115"
+          - "21116:21116"
+          - "21116:21116/udp"
+          - "21118:21118"
+        restart_policy: unless-stopped
+        memory: "{{ rustdesk_memory }}"
+  when: rustdesk_enabled is true
+
+- name: Stop rustdesk
+  block:
+    - name: Stop rustdesk
+      community.docker.docker_container:
+        name: "{{ rustdesk_container_name }}"
+        state: absent
+
+    - name: Stop rustdesk hbbr
+      community.docker.docker_container:
+        name: "{{ rustdesk_container_name }}-hbbr"
+        state: absent
+  when: rustdesk_enabled is false

--- a/website/docs/applications/other/rustdesk.md
+++ b/website/docs/applications/other/rustdesk.md
@@ -1,0 +1,15 @@
+# Rust Desk
+
+Homepage: <https://rustdesk.com>
+
+RustDesk is a full-featured remote desktop app. Works on Windows, macOS, Linux, iOS, Android, Web. Supports VP8 / VP9 / AV1 software codecs, and H264 / H265 hardware codecs. Own your data, easily set up self-hosting solution on your infrastructure. P2P connection with end-to-end encryption based on NaCl.
+
+## Usage
+
+Set `rustdesk_enabled: true` in your `inventories/<your_inventory>/nas.yml` file.
+
+The Rust Desk does not have web interface.
+
+## Specific Configuration
+
+Once Ansible-NAS has started the application you are ready to go. Just install the app on any system you want to remote and change only the ID Server to your rustdesk.domain.com or the ip of the Ansible-NAS Server.


### PR DESCRIPTION
**What this PR does / why we need it**:

Installs the RustDesk relay server.


**Any other useful info**:
RustDesk is a full-featured remote desktop app. Works on Windows, macOS, Linux, iOS, Android, Web. Own your data, easily set up self-hosting solution on your infrastructure.