### PR TITLE
Remove deprecated role geerlingguy.docker_arm

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -9,5 +9,4 @@ skip_list:
 exclude_paths:
  - roles/bertvv.samba
  - roles/geerlingguy.docker
- - roles/geerlingguy.docker_arm
  - roles/geerlingguy.nfs

--- a/nas.yml
+++ b/nas.yml
@@ -27,12 +27,6 @@
         - docker
         - skip_ansible_lint
 
-    - role: geerlingguy.docker_arm
-      when: ansible_architecture == "aarch64"
-      tags:
-        - docker_arm
-        - skip_ansible_lint
-
     ###
     ### Ansible-NAS Roles
     ###

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,9 +3,6 @@ roles:
   - name: geerlingguy.docker
     version: 6.0.0
 
-  - name: geerlingguy.docker_arm
-    version: 5.0.0
-
   - name: bertvv.samba
     version: v2.7.1
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes deprecated role `geerlingguy.docker_arm` (https://github.com/geerlingguy/ansible-role-docker_arm).
Ansible fails on ARM (M1 Apple silicone in my case) when this role is used.

**Which issue (if any) this PR fixes**:
-

**Any other useful info**:
-