### PR TITLE
Update Samba Shares website documentation

### DIFF
--- a/website/docs/further-configuration/samba-shares.md
+++ b/website/docs/further-configuration/samba-shares.md
@@ -1,6 +1,6 @@
 # Samba Shares
 
-Ansible-NAS uses the awesome [vladgh.samba](https://github.com/vladgh/ansible-collection-vladgh-samba) Ansible role to configure Samba - check out [the Ansible Galaxf page](https://galaxy.ansible.com/vladgh/samba) for the many different options you can use to configure a share.
+Ansible-NAS uses the awesome [vladgh.samba](https://github.com/vladgh/ansible-collection-vladgh-samba) Ansible role to configure Samba - check out [the Ansible Galaxy page](https://galaxy.ansible.com/vladgh/samba) for the many different options you can use to configure a share.
 
 ## Share Examples
 

--- a/website/docs/further-configuration/samba-shares.md
+++ b/website/docs/further-configuration/samba-shares.md
@@ -1,6 +1,6 @@
 # Samba Shares
 
-Ansible-NAS uses the awesome [bertvv.samba](https://github.com/bertvv/ansible-role-samba) Ansible role to configure Samba - check out the project page for the many different options you can use to configure a share.
+Ansible-NAS uses the awesome [vladgh.samba](https://github.com/vladgh/ansible-collection-vladgh-samba) Ansible role to configure Samba - check out [the Ansible Galaxf page](https://galaxy.ansible.com/vladgh/samba) for the many different options you can use to configure a share.
 
 ## Share Examples
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the existing documentation for Samba Shares to link to the actively maintained project `vladgh.samba` instead of the stale project `bertvv.samba`.
