### PR TITLE
Fix minecraft docker folder creation

### DIFF
--- a/roles/minecraft-bedrock-server/tasks/main.yml
+++ b/roles/minecraft-bedrock-server/tasks/main.yml
@@ -1,13 +1,13 @@
 ---
-- name: Create Minecraft Bedrock Server Directories
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: directory
-  with_items:
-    - "{{ minecraft_bedrock_server_data_directory }}"
-
 - name: Start Minecraft Bedrock Server
   block:
+    - name: Create Minecraft Bedrock Server Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - "{{ minecraft_bedrock_server_data_directory }}"
+
     - name: Minecraft Bedrock Server Docker Container
       community.docker.docker_container:
         name: "{{ minecraft_bedrock_server_container_name }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The minecraft bedrock server folder was being created even when not configured to be installed.

**Which issue (if any) this PR fixes**:

N/A

**Any other useful info**:

Not a big deal but I noticed this weird folder on my server. This solves it.