### PR TITLE
Fix Piwigo startup and docs for #614

### DIFF
--- a/roles/piwigo/defaults/main.yml
+++ b/roles/piwigo/defaults/main.yml
@@ -8,8 +8,8 @@ piwigo_data_directory: "{{ docker_home }}/piwigo/data"
 piwigo_photos: "{{ photos_root }}/piwigo"
 
 # uid / gid
-piwigo_user_id: "0"
-piwigo_group_id: "0"
+piwigo_user_id: "1"
+piwigo_group_id: "1"
 piwigo_mysql_user: "piwigo"
 piwigo_mysql_password: "piwigo"
 piwigo_mysql_root_password: "piwigo"

--- a/roles/piwigo/defaults/main.yml
+++ b/roles/piwigo/defaults/main.yml
@@ -8,8 +8,8 @@ piwigo_data_directory: "{{ docker_home }}/piwigo/data"
 piwigo_photos: "{{ photos_root }}/piwigo"
 
 # uid / gid
-piwigo_user_id: "1"
-piwigo_group_id: "1"
+piwigo_user_id: "1000"
+piwigo_group_id: "1000"
 piwigo_mysql_user: "piwigo"
 piwigo_mysql_password: "piwigo"
 piwigo_mysql_root_password: "piwigo"

--- a/website/docs/applications/other/piwigo.md
+++ b/website/docs/applications/other/piwigo.md
@@ -23,8 +23,8 @@ Optional configurations:
 - Set `piwigo_mysql_root_password` in `inventories/<your_inventory>/group_vars/nas.yml` before installing Piwigo, this defaults to "piwigo".
 
 - On first run you'll need to enter database details:
-  - Host: `db:3306`
-  - Username: the value of piwigo_mysql_user, defaults to "piwigo"
-  - Password: the value of piwigo_password, defaults to "piwigo"
+  - Host: `piwigo-db`
+  - Username: the value of piwigo_mysql_user, defaults to `piwigo`
+  - Password: the value of piwigo_password, defaults to `piwigo`
   - Database Name: `piwigo`
   - Database tables prefix: should be prefilled with `piwigo_`


### PR DESCRIPTION
The host name in the docs is incorrect. I managed to make it work as per: https://www.youtube.com/watch?v=hIGibqdSo6c

Also, piwigo refuses to start with the root user. Changed it to `1` for the current user
