### PR TITLE
Add steamgriddb and mobygames api keys. Change base image for romm

### DIFF
--- a/roles/romm/defaults/main.yml
+++ b/roles/romm/defaults/main.yml
@@ -18,7 +18,7 @@ romm_hostname: "romm"
 
 # docker
 romm_container_name: "romm"
-romm_image_name: "zurdi15/romm"
+romm_image_name: "rommapp/romm"
 romm_image_version: "latest"
 
 romm_db_container_name: "romm-db"
@@ -37,6 +37,12 @@ romm_redis_memory: 1g
 # IGDB auth credentials - see https://github.com/zurdi15/romm/tree/release#-docker for more info
 romm_igdb_client_id: "abcd"
 romm_igdb_client_secret: "abcd"
+
+# MobyGames auth credentials
+romm_mobygames_client_id: "abcd"
+
+# SteamGridDB auth credentials
+romm_steamgriddb_client_id: "abcd"
 
 # auth config
 romm_auth_secret_key: "aaaabbbbccccdddd" # Generate a key with `openssl rand -hex 32`

--- a/roles/romm/tasks/main.yml
+++ b/roles/romm/tasks/main.yml
@@ -56,6 +56,8 @@
           REDIS_PORT: "6379"
           IGDB_CLIENT_ID: "{{ romm_igdb_client_id }}"
           IGDB_CLIENT_SECRET: "{{ romm_igdb_client_secret }}"
+          MOBYGAMES_API_KEY: "{{ romm_mobygames_client_id }}"
+          STEAMGRIDDB_API_KEY: "{{ romm_steamgriddb_client_id }}"
           ROMM_AUTH_USERNAME: "{{ romm_auth_username }}"
           ROMM_AUTH_PASSWORD: "{{ romm_auth_password }}"
         restart_policy: unless-stopped


### PR DESCRIPTION
**What this PR does / why we need it**:

RomM migrated the base image. We change to the new one to avoid a message as soon as we start the application.

In addition, we added the other two possible API keys to obtain video game data.

**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
