### PR TITLE
Fixed wallabag SYMFONY__ENV__DOMAIN_NAME to be the same with wallabag_hostname

### DIFF
--- a/roles/wallabag/tasks/main.yml
+++ b/roles/wallabag/tasks/main.yml
@@ -23,7 +23,7 @@
         ports:
           - "{{ wallabag_port }}:80"
         env:
-          SYMFONY__ENV__DOMAIN_NAME: "https://wallabag.{{ ansible_nas_domain }}"
+          SYMFONY__ENV__DOMAIN_NAME: "https://{{ wallabag_hostname }}.{{ ansible_nas_domain }}"
         restart_policy: unless-stopped
         memory: "{{ wallabag_memory }}"
         labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

If `wallabag_hostname` configured to anything different than "wallabag", the front-end isn't rendered correctly because the static files are pointing to `wallabag.{{ ansible_nas_domain }}`

**Which issue (if any) this PR fixes**:

n/a

**Any other useful info**:

n/a