### PR TITLE
Make dashboards available on main domain (not subdomain)

### DIFF
--- a/roles/dashy/tasks/main.yml
+++ b/roles/dashy/tasks/main.yml
@@ -27,7 +27,7 @@
           - "{{ dashy_data_directory }}/conf.yml:/app/public/conf.yml:rw"
         labels:
           traefik.enable: "{{ dashy_available_externally | string }}"
-          traefik.http.routers.dashy.rule: "Host(`{{ dashy_hostname }}.{{ ansible_nas_domain }}`)"
+          traefik.http.routers.dashy.rule: "Host(`{{ homepage_hostname }}{% if homepage_hostname != '' %}.{% endif %}{{ ansible_nas_domain }}`)"
           traefik.http.routers.dashy.tls.certresolver: "letsencrypt"
           traefik.http.routers.dashy.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.dashy.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"

--- a/roles/heimdall/tasks/main.yml
+++ b/roles/heimdall/tasks/main.yml
@@ -25,7 +25,7 @@
         memory: "{{ heimdall_memory }}"
         labels:
           traefik.enable: "{{ heimdall_available_externally | string }}"
-          traefik.http.routers.heimdall.rule: "Host(`{{ heimdall_hostname }}.{{ ansible_nas_domain }}`)"
+          traefik.http.routers.heimdall.rule: "Host(`{{ heimdall_hostname }}{% if heimdall_hostname != '' %}.{% endif %}{{ ansible_nas_domain }}`)"
           traefik.http.routers.heimdall.tls.certresolver: "letsencrypt"
           traefik.http.routers.heimdall.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.heimdall.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"

--- a/roles/homepage/tasks/main.yml
+++ b/roles/homepage/tasks/main.yml
@@ -37,7 +37,7 @@
         memory: "{{ homepage_memory }}"
         labels:
           traefik.enable: "{{ homepage_available_externally | string }}"
-          traefik.http.routers.homepage.rule: "Host(`{{ homepage_hostname }}.{{ ansible_nas_domain }}`)"
+          traefik.http.routers.homepage.rule: "Host(`{{ homepage_hostname }}{% if homepage_hostname != '' %}.{% endif %}{{ ansible_nas_domain }}`)"
           traefik.http.routers.homepage.tls.certresolver: "letsencrypt"
           traefik.http.routers.homepage.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.homepage.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"

--- a/roles/organizr/tasks/main.yml
+++ b/roles/organizr/tasks/main.yml
@@ -26,7 +26,7 @@
         memory: "{{ organizr_memory }}"
         labels:
           traefik.enable: "{{ organizr_available_externally | string }}"
-          traefik.http.routers.organizr.rule: "Host(`{{ organizr_hostname }}.{{ ansible_nas_domain }}`)"
+          traefik.http.routers.organizr.rule: "Host(`{{ organizr_hostname }}{% if organizr_hostname != '' %}.{% endif %}{{ ansible_nas_domain }}`)"
           traefik.http.routers.organizr.tls.certresolver: "letsencrypt"
           traefik.http.routers.organizr.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.organizr.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"

--- a/website/docs/applications/dashboards/dashy.md
+++ b/website/docs/applications/dashboards/dashy.md
@@ -13,3 +13,7 @@ All the code is free and open source, and everything is thoroughly documented, y
 Set `dashy_enabled: true` in your `inventories/<your_inventory>/group_vars/nas.yml` file.
 
 The Dashy web interface can be found at [http://ansible_nas_host_or_ip:8082](http://ansible_nas_host_or_ip:8082).
+
+## Specific Configuration
+
+If you are using domain name (suppose, all your apps are using `<subdomain>.example.com`), but for your main dashboard you want it to be just `example.com` (without subdomain), you can achieve this by setting `dashy_hostname` to an empty, i.e. `dashy_hostname: ''`

--- a/website/docs/applications/dashboards/heimdall.md
+++ b/website/docs/applications/dashboards/heimdall.md
@@ -15,3 +15,5 @@ The Heimdall web interface can be found at [http://ansible_nas_host_or_ip:10080]
 ## Specific Configuration
 
 Heimdall defaults to port 10080 - some browsers block this port. Override `heimdall_port_http` to move it somewhere else.
+
+If you are using domain name (suppose, all your apps are using `<subdomain>.example.com`), but for your main dashboard you want it to be just `example.com` (without subdomain), you can achieve this by setting `heimdall_hostname` to an empty, i.e. `heimdall_hostname: ''`

--- a/website/docs/applications/dashboards/homepage.md
+++ b/website/docs/applications/dashboards/homepage.md
@@ -16,4 +16,4 @@ The Homepage web interface can be found at [http://ansible_nas_host_or_ip:11111]
 
 ## Specific Configuration
 
-Heimdall defaults to port 10080 - some browsers block this port. Override `heimdall_port_http` to move it somewhere else.
+If you are using domain name (suppose, all your apps are using `<subdomain>.example.com`), but for your main dashboard you want it to be just `example.com` (without subdomain), you can achieve this by setting `homepage_hostname` to an empty, i.e. `homepage_hostname: ''`

--- a/website/docs/applications/dashboards/organizr.md
+++ b/website/docs/applications/dashboards/organizr.md
@@ -11,3 +11,7 @@ HTPC/Homelab services organizer written in PHP.
 Set `organizr_enabled: true` in your `inventories/<your_inventory>/group_vars/nas.yml` file.
 
 The Organizr web interface can be found at [http://ansible_nas_host_or_ip:10081](http://ansible_nas_host_or_ip:10081).
+
+## Specific Configuration
+
+If you are using domain name (suppose, all your apps are using `<subdomain>.example.com`), but for your main dashboard you want it to be just `example.com` (without subdomain), you can achieve this by setting `organizr_hostname` to an empty, i.e. `organizr_hostname: ''`


### PR DESCRIPTION
**What this PR does / why we need it**:

It's kinda nice to have main dashboard on main domain (not subdomain like other apps), so this PR adds just this by setting `<dashboard_name>_hostname` to an empty string, i.e. `homepage_hostname: ''` in inventory group vars. I also removed copy-pasted from heimdall into homepage "Specific Configuration" section.  

**Which issue (if any) this PR fixes**:

none, I did it for my own fork, sharing back to the community

**Any other useful info**:

all the useful info is in the description and code :)