### PR TITLE
Fix missing recordings_root default var

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -74,6 +74,9 @@ code_root: "{{ samba_shares_root }}/code"
 # Where roms are stored
 roms_root: "{{ samba_shares_root }}/roms"
 
+# Where recordings are stored
+recordings_root: "{{ samba_shares_root }}/recordings"
+
 # The description that'll appear next to your Ansible-NAS box when browsing your network
 samba_server_string: Ansible NAS
 


### PR DESCRIPTION
**What this PR does / why we need it**:

A ["recordings" samba share](https://github.com/davestephens/ansible-nas/blob/05dab3e6e11218a9c7237b3d58ef75ea1058024c/group_vars/all.yml#L186) was added in 05dab3e6e11218a9c7237b3d58ef75ea1058024c but did not include a default recordings_root path variable. This commit adds the variable

While small, this issue prevented the default playbook with only the minimum necessary edits from running on a clean host.
