### PR TITLE
Remove ctop because it is not working in Ubuntu 22.x and removed from 24.x

### DIFF
--- a/roles/ansible-nas-general/defaults/main.yml
+++ b/roles/ansible-nas-general/defaults/main.yml
@@ -13,7 +13,6 @@ ansible_nas_extra_packages:
   - bonnie++
   - unzip
   - lm-sensors
-  - ctop
 
 # Sets the timezone for your Ansible NAS
 # You can find a list here https://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
Fixes

* Fix installation on Ubuntu 24.x