### PR TITLE
FIX: portainer - change lb.server.port 9443->9000

### DIFF
--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -32,7 +32,7 @@
           traefik.http.routers.portainer.tls.certresolver: "letsencrypt"
           traefik.http.routers.portainer.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.portainer.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
-          traefik.http.services.portainer.loadbalancer.server.port: "9443"
+          traefik.http.services.portainer.loadbalancer.server.port: "9000"
           traefik.http.routers.portainer.middlewares: "portainer-ipallowlist@docker"
           traefik.http.middlewares.portainer-ipallowlist.ipallowlist.sourcerange: "{{ portainer_ip_allowlist }}"
           homepage.group: System Tools


### PR DESCRIPTION
**What this PR does / why we need it**:
Changes loadbalancer.server.port used for traefik back to 9000 as on port 9443 portainer is using it's own ssl cert and it looks like traefik is not able to properly connect to this self-signed cert. When using port 9000 there are no issues and portainer is properly exposed via traefik.

**Any other useful info**:
I have tried different aproaches. 

I've set:
- `traefik.http.services.portainer.loadbalancer.server.scheme: "https"`
- tried changing `portainer_port` to 9443
- removed my `portainer_ip_allowlist`

If someone has a working example with port 9443 for `loadbalancer.server.port` please explain how does that work. 