### PR TITLE
Fix Portainer Traefik and Homepage

### DIFF
--- a/roles/portainer/defaults/main.yml
+++ b/roles/portainer/defaults/main.yml
@@ -17,3 +17,7 @@ portainer_image_version: "latest"
 
 # specs
 portainer_memory: 1g
+
+# homepage
+# https://gethomepage.dev/widgets/services/portainer/
+portainer_homepage_environment_id : 3

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -32,13 +32,13 @@
           traefik.http.routers.portainer.tls.certresolver: "letsencrypt"
           traefik.http.routers.portainer.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.portainer.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
-          traefik.http.services.portainer.loadbalancer.server.port: "9443"
+          traefik.http.services.portainer.loadbalancer.server.port: "{{ portainer_port }}"
           traefik.http.routers.portainer.middlewares: "portainer-ipallowlist@docker"
           traefik.http.middlewares.portainer-ipallowlist.ipallowlist.sourcerange: "{{ portainer_ip_allowlist }}"
           homepage.group: System Tools
           homepage.name: Portainer
           homepage.icon: portainer.png
-          homepage.href: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ portainer_port }}"
+          homepage.href: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ portainer_port }}"
           homepage.description: Container management
           homepage.widget.type: portainer
           homepage.widget.url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ portainer_port }}"

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -41,7 +41,8 @@
           homepage.href: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ portainer_port }}"
           homepage.description: Container management
           homepage.widget.type: portainer
-          homepage.widget.url: "https://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ portainer_port }}"
+          homepage.widget.url: "http://{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:{{ portainer_port }}"
+          homepage.widget.env: "{{ portainer_homepage_environment_id }}"
   when: portainer_enabled is true
 
 - name: Stop Portainer

--- a/roles/portainer/tasks/main.yml
+++ b/roles/portainer/tasks/main.yml
@@ -32,7 +32,7 @@
           traefik.http.routers.portainer.tls.certresolver: "letsencrypt"
           traefik.http.routers.portainer.tls.domains[0].main: "{{ ansible_nas_domain }}"
           traefik.http.routers.portainer.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
-          traefik.http.services.portainer.loadbalancer.server.port: "{{ portainer_port }}"
+          traefik.http.services.portainer.loadbalancer.server.port: "9000"
           traefik.http.routers.portainer.middlewares: "portainer-ipallowlist@docker"
           traefik.http.middlewares.portainer-ipallowlist.ipallowlist.sourcerange: "{{ portainer_ip_allowlist }}"
           homepage.group: System Tools


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR restores remote access and homepage linking to Portainer.


**Which issue (if any) this PR fixes**:

Fixes #

**Any other useful info**:
- It looks like the homepage href `https` was put there on the initial homepage add in a4a218222 by @gabrielgradinaru. https doesn't really work by default on the local network so I think it should be http. Any thoughts?
- The traefik port discrepancy came about in 4b953b8c4 by @davestephens . I think it was just a missed detail with the port change.