### PR TITLE
New application - Audiobookshelf, successor to Booksonic which is sti…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ If you have a spare domain name you can configure applications to be accessible 
 
 * [Airsonic](https://airsonic.github.io/) - catalog and stream music
 * [Apcupsd](http://www.apcupsd.org/) - A daemon for controlling APC UPSes
+* [Audiobookshelf](https://www.audiobookshelf.org/) - Catalog and stream audiobooks to web or mobile clients
 * [Bazarr](https://github.com/morpheus65535/bazarr) - companion to Radarr and Sonarr for downloading subtitles
 * [Bitwarden](https://github.com/dani-garcia/vaultwarden) - Password Manger (Technically Vaultwarden, a lightweight implementation in Rust)
 * [Booksonic](https://booksonic.org/) - The selfhosted audiobook server

--- a/roles/audiobookshelf/defaults/main.yml
+++ b/roles/audiobookshelf/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+audiobookshelf_enabled: false
+audiobookshelf_available_externally: false
+
+# uid / gid
+audiobookshelf_user_id: "1000"
+audiobookshelf_group_id: "1000"
+
+# directories
+audiobookshelf_data_directory: "{{ docker_home }}/audiobookshelf"
+audiobookshelf_audiobooks_directory: "{{ audiobooks_root }}"
+audiobookshelf_podcasts_directory: "{{ podcasts_root }}"
+
+# network
+audiobookshelf_port: "13378"
+audiobookshelf_hostname: "audiobookshelf"
+
+# specs
+audiobookshelf_memory: 1g
+
+# docker
+audiobookshelf_container_name: audiobookshelf

--- a/roles/audiobookshelf/molecule/default/molecule.yml
+++ b/roles/audiobookshelf/molecule/default/molecule.yml
@@ -1,0 +1,6 @@
+---
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        audiobookshelf_enabled: true

--- a/roles/audiobookshelf/molecule/default/side_effect.yml
+++ b/roles/audiobookshelf/molecule/default/side_effect.yml
@@ -1,0 +1,10 @@
+---
+- name: Stop
+  hosts: all
+  become: true
+  tasks:
+    - name: "Include {{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }} role"
+      ansible.builtin.include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
+      vars:
+        audiobookshelf_enabled: false

--- a/roles/audiobookshelf/molecule/default/verify.yml
+++ b/roles/audiobookshelf/molecule/default/verify.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Get container state
+      community.docker.docker_container_info:
+        name: "{{ audiobookshelf_container_name }}"
+      register: result
+
+    - name: Check Audiobookshelf is running
+      ansible.builtin.assert:
+        that:
+          - result.container['State']['Status'] == "running"
+          - result.container['State']['Restarting'] == false

--- a/roles/audiobookshelf/molecule/default/verify_stopped.yml
+++ b/roles/audiobookshelf/molecule/default/verify_stopped.yml
@@ -1,0 +1,18 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - ansible.builtin.include_vars:
+        file: ../../defaults/main.yml
+
+    - name: Try and stop and remove Audiobookshelf
+      community.docker.docker_container:
+        name: "{{ audiobookshelf_container_name }}"
+        state: absent
+      register: result
+
+    - name: Check Audiobookshelf is stopped
+      ansible.builtin.assert:
+        that:
+          - not result.changed

--- a/roles/audiobookshelf/tasks/main.yml
+++ b/roles/audiobookshelf/tasks/main.yml
@@ -16,10 +16,10 @@
         image: ghcr.io/advplyr/audiobookshelf:latest
         pull: true
         volumes:
-          - "{{ audiobookshelf_data_directory }}/data:/audiobookshelf/metadata:rw"
-          - "{{ audiobookshelf_data_directory }}/playlists:/audiobookshelf/config:rw"
-          - "{{ audiobookshelf_audiobooks_directory }}:/audiobookshelf/audiobooks:rw"
-          - "{{ audiobookshelf_podcasts_directory }}:/audiobookshelf/podcasts:rw"
+          - "{{ audiobookshelf_data_directory }}/metadata:/metadata:rw"
+          - "{{ audiobookshelf_data_directory }}/config:/config:rw"
+          - "{{ audiobookshelf_audiobooks_directory }}:/audiobooks:rw"
+          - "{{ audiobookshelf_podcasts_directory }}:/podcasts:rw"
         ports:
           - "{{ audiobookshelf_port }}:80"
         env:

--- a/roles/audiobookshelf/tasks/main.yml
+++ b/roles/audiobookshelf/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: Start Audiobookshelf
+  block:
+    - name: Create Audiobookshelf Directories
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: 0755
+      with_items:
+        - "{{ audiobookshelf_data_directory }}/metadata"
+        - "{{ audiobookshelf_data_directory }}/config"
+
+    - name: Audiobookshelf Docker Container
+      community.docker.docker_container:
+        name: "{{ audiobookshelf_container_name }}"
+        image: ghcr.io/advplyr/audiobookshelf:latest
+        pull: true
+        volumes:
+          - "{{ audiobookshelf_data_directory }}/data:/audiobookshelf/metadata:rw"
+          - "{{ audiobookshelf_data_directory }}/playlists:/audiobookshelf/config:rw"
+          - "{{ audiobookshelf_audiobooks_directory }}:/audiobookshelf/audiobooks:rw"
+          - "{{ audiobookshelf_podcasts_directory }}:/audiobookshelf/podcasts:rw"
+        ports:
+          - "{{ audiobookshelf_port }}:80"
+        env:
+          TZ: "{{ ansible_nas_timezone }}"
+          PUID: "{{ audiobookshelf_user_id }}"
+          PGID: "{{ audiobookshelf_group_id }}"
+        restart_policy: unless-stopped
+        memory: "{{ audiobookshelf_memory }}"
+        labels:
+          traefik.enable: "{{ audiobookshelf_available_externally | string }}"
+          traefik.http.routers.audiobookshelf.rule: "Host(`{{ audiobookshelf_hostname }}.{{ ansible_nas_domain }}`)"
+          traefik.http.routers.audiobookshelf.tls.certresolver: "letsencrypt"
+          traefik.http.routers.audiobookshelf.tls.domains[0].main: "{{ ansible_nas_domain }}"
+          traefik.http.routers.audiobookshelf.tls.domains[0].sans: "*.{{ ansible_nas_domain }}"
+          traefik.http.services.audiobookshelf.loadbalancer.server.port: "80"
+  when: audiobookshelf_enabled is true
+
+- name: Stop Audiobookshelf
+  block:
+    - name: Stop Audiobookshelf
+      community.docker.docker_container:
+        name: "{{ audiobookshelf_container_name }}"
+        state: absent
+  when: audiobookshelf_enabled is false

--- a/website/docs/applications/media-serving/audiobookshelf.md
+++ b/website/docs/applications/media-serving/audiobookshelf.md
@@ -1,0 +1,21 @@
+---
+title: "Audiobookshelf"
+---
+
+Homepage: [https://audiobookshelf.org/](https://audiobookshelf.org/)
+
+Manage and stream your audiobooks to Web and mobile clients. Audiobookshelf is a successor to Booksonic and similar applications and is still being actively supported by the developers. The applicaiton is backed by a metadata DB so if you have an unsorted audiobook collection, you will get a more friendly view than filesystem based alternatives. 
+
+You can find the code on [GitHub](https://github.com/advplyr/audiobookshelf)
+
+Get the Android app on [Google Play](https://play.google.com/store/apps/details?id=com.audiobookshelf.app) or the equivalent iOS app via [TestFlight](https://testflight.apple.com/join/wiic7QIW).
+
+## Usage
+
+Set `audiobookshelf_enabled: true` in your `inventories/<your_inventory>/group_vars/nas.yml` file.
+
+The Audiobookshelf web interface can be found at [http://ansible_nas_host_or_ip:13378](http://ansible_nas_host_or_ip:13378).
+
+## Specific Configuration
+
+There is no default password, you'll will be prompted to set this at first login. It's therefore important you do this quickly after provisioning is complete. 

--- a/website/docs/applications/media-serving/audiobookshelf.md
+++ b/website/docs/applications/media-serving/audiobookshelf.md
@@ -4,7 +4,7 @@ title: "Audiobookshelf"
 
 Homepage: [https://audiobookshelf.org/](https://audiobookshelf.org/)
 
-Manage and stream your audiobooks to Web and mobile clients. Audiobookshelf is a successor to Booksonic and similar applications and is still being actively supported by the developers. The applicaiton is backed by a metadata DB so if you have an unsorted audiobook collection, you will get a more friendly view than filesystem based alternatives. 
+Manage and stream your audiobooks to Web and mobile clients. Audiobookshelf is a successor to Booksonic and similar applications and is still being actively supported by the developers. The applicaiton is backed by a metadata DB so if you have an unsorted audiobook collection, you will get a more friendly view than filesystem based alternatives.
 
 You can find the code on [GitHub](https://github.com/advplyr/audiobookshelf)
 
@@ -18,4 +18,4 @@ The Audiobookshelf web interface can be found at [http://ansible_nas_host_or_ip:
 
 ## Specific Configuration
 
-There is no default password, you'll will be prompted to set this at first login. It's therefore important you do this quickly after provisioning is complete. 
+There is no default password, you'll will be prompted to set this at first login. It's therefore important you do this quickly after provisioning is complete.


### PR DESCRIPTION
**What this PR does / why we need it**:

Booksonic has been out of support for some time now and on some architectures the latest tag will fail to pull in docker. Whilst this can be fixed ad-hoc by updating tags locally, I think offering Audiobookshelf, a successor project, is probably a better long term solution. 


**Which issue (if any) this PR fixes**:

I'll be honest, I haven't made a PR to anything for a long time and I'm so busy I barely had time to do this one, but a cursory check tells me there are no open Audiobook related issues. 

**Any other useful info**:

I am not a real developer, so this PR is likely to benefit from a deeper-than-usual QA from yourself :) It is working fine on my system and in Vagrant, so fingers crossed!